### PR TITLE
fix not considering some commas as literals

### DIFF
--- a/src/attributes.rst
+++ b/src/attributes.rst
@@ -38,7 +38,7 @@ Attributes
      | $$=$$ Expression
 
    AttributeContentList ::=
-       AttributeContent (, AttributeContent)* ,?
+       AttributeContent ($$,$$ AttributeContent)* $$,$$?
 
 .. rubric:: Legality Rules
 
@@ -472,7 +472,7 @@ Attribute ``target_feature``
        $$target_feature$$ $$($$ $$enable$$ $$=$$ $$"$$ FeatureList $$"$$ $$)$$
 
    FeatureList ::=
-       Feature (, Feature)*
+       Feature ($$,$$ Feature)*
 
    Feature ::=
        $$adx$$
@@ -1030,7 +1030,7 @@ Attribute ``link``
        $$name$$ $$=$$ StringLiteral
 
    NativeLibraryNameWithKind ::=
-       NativeLibraryName , NativeLibrayKind
+       NativeLibraryName $$,$$ NativeLibrayKind
 
    WebAssemblyModuleName ::=
        $$wasm_import_module$$ $$=$$ StringLiteral

--- a/src/generics.rst
+++ b/src/generics.rst
@@ -246,7 +246,7 @@ Where Clauses
        $$where$$ WhereClausePredicateList
 
    WhereClausePredicateList ::=
-       WhereClausePredicate (, WhereClausePredicate)* $$,$$?
+       WhereClausePredicate ($$,$$ WhereClausePredicate)* $$,$$?
 
    WhereClausePredicate ::=
        LifetimeBoundPredicate

--- a/src/patterns.rst
+++ b/src/patterns.rst
@@ -769,13 +769,13 @@ Record Struct Patterns
 
    RecordStructPatternContent ::=
        RecordStructRestPattern
-     | FieldDeconstructorList (, RecordStructRestPattern | ,?)
+     | FieldDeconstructorList ($$,$$ RecordStructRestPattern | $$,$$?)
 
    RecordStructRestPattern ::=
        OuterAttributeOrDoc* RestPattern
 
    FieldDeconstructorList ::=
-       FieldDeconstructor (, FieldDeconstructor)*
+       FieldDeconstructor ($$,$$ FieldDeconstructor)*
 
    FieldDeconstructor ::=
        OuterAttributeOrDoc* (

--- a/src/types-and-traits.rst
+++ b/src/types-and-traits.rst
@@ -23,7 +23,7 @@ Types
      | TypeSpecificationWithoutBounds
 
    TypeSpecificationList ::=
-       TypeSpecification (, TypeSpecification)* $$,$$?
+       TypeSpecification ($$,$$ TypeSpecification)* $$,$$?
 
    TypeSpecificationWithoutBounds ::=
        ArrayTypeSpecification
@@ -576,7 +576,7 @@ Tuple Types
        $$($$ TupleFieldList? $$)$$
 
    TupleFieldList ::=
-       TupleField (, TupleField)* ,?
+       TupleField ($$,$$ TupleField)* $$,$$?
 
    TupleField ::=
        TypeSpecification


### PR DESCRIPTION
In some cases, especially after parentheses, commas are mistakenly not considered as "literal characters" (per 1.1.4:7) because they are not wrapped in `$$` signs.

    $ rg '\(\$\$,\$\$' | wc -l
    27

    $ rg '\(,' | wc -l
    7