### PR TITLE
Instruct linguist to include ``.rst`` files in the statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Rust Project Developers
+
+# Instruct linguist not to ignore the main content
+# https://github.com/github-linguist/linguist/blob/master/docs/overrides.md
+src/*.rst text linguist-detectable


### PR DESCRIPTION
Currently this appears to be a Python repo in the sidebar, as GitHub's Linguist ignores prose files by default.

We adopted a similar approach in the Python project (see: https://github.com/python/peps/pull/3430).

A