### PR TITLE
document 1.86 language changes

### DIFF
--- a/src/attributes.rst
+++ b/src/attributes.rst
@@ -503,7 +503,9 @@ Attribute ``target_feature``
 .. rubric:: Legality Rules
 
 :dp:`fls_3qj3jvmtxvx6`
-:t:`Attribute` :c:`target_feature` shall apply to :t:`[unsafe function]s`.
+Safe :t:`[function]s` that are annotated with :c:`[target_feature]s`
+can only be called without an :t:`unsafe block` by a caller that is within a function
+that enables all the :c:`[target_feature]s` that the callee enables.
 
 :dp:`fls_agpkz1v3c281`
 :t:`Attribute` :dc:`target_feature` enables target architecture features for its

--- a/src/changelog.rst
+++ b/src/changelog.rst
@@ -18,6 +18,37 @@ with the change that has been applied due to it.
    just the language changes that had an impact to the FLS. See the `release
    notes`_ for a full list of changes.
 
+Language changes in Rust 1.86.0
+-------------------------------
+
+- `Stabilize upcasting trait objects to supertraits. <https://github.com/rust-lang/rust/pull/134367>`_
+
+  - New paragraph: :p:`fls_QB4c6FNKxaPl`
+
+- `Allow safe functions to be marked with the #[target_feature] attribute. <https://github.com/rust-lang/rust/pull/134090>`_
+
+  - Changed paragraph: :p:`fls_3qj3jvmtxvx6`
+
+- `The missing_abi lint now warns-by-default. <https://github.com/rust-lang/rust/pull/132397>`_
+
+  - No change: Lints are not part of the FLS
+
+- `Rust now lints about double negations, to catch cases that might have intended to be a prefix decrement operator (--x) as written in other languages. This was previously a clippy lint, clippy::double_neg, and is now available directly in Rust as double_negations. <https://github.com/rust-lang/rust/pull/126604>`_
+
+  - No change: Lints are not part of the FLS
+
+- `More pointers are now detected as definitely not-null based on their alignment in const eval. <https://github.com/rust-lang/rust/pull/133700>`_
+
+  - No change: The concrete semantics of constant evaluation is not described within the FLS
+
+- `Empty repr() attribute applied to invalid items are now correctly rejected. <https://github.com/rust-lang/rust/pull/133925>`_
+
+  - No change: this bug was not documented
+
+- `Inner attributes, #![test] and #![rustfmt::skip], are no longer accepted in more places than intended. <https://github.com/rust-lang/rust/pull/134276>`_
+
+  - No change: These attributes are not part of the FLS
+
 Language changes in Rust 1.85.0
 -------------------------------
 

--- a/src/types-and-traits.rst
+++ b/src/types-and-traits.rst
@@ -2048,6 +2048,11 @@ occur when:
 * :dp:`fls_SYnFJBhi0IWj`
   The source :t:`type` is a :t:`trait object type` and the target :t:`type` is a :t:`trait object type` with the same or no :t:`principal trait`, and the target :t:`type` has the same or less non-:t:`principal trait` :t:`[trait bound]s`.
 
+* :dp:`fls_QB4c6FNKxaPl`
+  The source :t:`type` is a :t:`trait object type` with some :t:`principal trait` ``T``
+  and the target :t:`type` is a :t:`trait object type` with some :t:`principal trait` ``U``,
+  where ``U`` is a :t:`supertrait` of ``T``.
+
 :dp:`fls_iiiu2q7pym4p`
 An :t:`unsized coercion` is a :t:`type coercion` that converts a :t:`sized type`
 into an :t:`unsized type`. :t:`Unsized coercion` from a source :t:`type` to a

--- a/version.rst
+++ b/version.rst
@@ -1,3 +1,3 @@
 .. SPDX-License-Identifier: MIT OR Apache-2.0
    SPDX-FileCopyrightText: The Ferrocene Developers
-.. |spec_version| replace:: 1.84.0
+.. |spec_version| replace:: 1.86.0


### PR DESCRIPTION
These are additions Ferrocene has in its FLS subtree (see https://github.com/ferrocene/ferrocene/pull/1460).

For some context, our process is
- We use [text in the release notes](https://doc.rust-lang.org/releases.html#version-1860-2025-04-03)
- We decide what is relevant for the FLS
- We add relevant changes, or amend existing text

sidenote: On the Ferrocene side, we annotate tests with new ids ([example](https://github.com/ferrocene/ferrocene/commit/11b9c86afa1bd687d1c8add6da1fc665beb89467))