### PR TITLE
ensure all terms in glossary also exist in main text

### DIFF
--- a/exts/ferrocene_spec/definitions/__init__.py
+++ b/exts/ferrocene_spec/definitions/__init__.py
@@ -150,9 +150,9 @@ class DefinitionsTransform(SphinxTransform):
                     )
                 else:
                     if node["ref_kind"] == "term":
-                        print(
-                            f"warn: document={node['ref_source_doc']} has dangling term, {node['ref_text']}"
-                        )
+                        doc = node["ref_source_doc"]
+                        text = node["ref_text"]
+                        print(f"warn: document={doc} has dangling term, {text}")
                     new = nodes.inline(
                         "",
                         "",

--- a/exts/ferrocene_spec/definitions/__init__.py
+++ b/exts/ferrocene_spec/definitions/__init__.py
@@ -149,6 +149,10 @@ class DefinitionsTransform(SphinxTransform):
                         )
                     )
                 else:
+                    if node["ref_kind"] == "term":
+                        print(
+                            f"warn: document={node['ref_source_doc']} has dangling term, {node['ref_text']}"
+                        )
                     new = nodes.inline(
                         "",
                         "",

--- a/src/changelog.rst
+++ b/src/changelog.rst
@@ -30,6 +30,7 @@ FLS maintenance
   - :p:`fls_twC8XhwbI60x`
   - :p:`fls_9bp4cKSfW9A0`
   - :p:`fls_Odh6Z7ivD1U4`
+  - :p:`fls_FG0EmVgrDUDq`
 
 - Paragraphs changed to avoid referencing indirect terms:
 

--- a/src/changelog.rst
+++ b/src/changelog.rst
@@ -57,6 +57,10 @@ FLS maintenance
   - :p:`fls_9d970yfwmj2d`
   - :p:`fls_p9687v3xckps`
   - :p:`fls_8j408kckzzud`
+  - :p:`fls_mdejdc0nNgyO`
+  - :p:`fls_WUCvCauUCmsD`
+  - :p:`fls_5SVthCNZBcVS`
+  - :p:`fls_SonodAQVL5J4`
 
 Language changes in Rust 1.94.0
 -------------------------------

--- a/src/changelog.rst
+++ b/src/changelog.rst
@@ -29,6 +29,32 @@ FLS maintenance
   - :p:`fls_hyi2jnp38v1n`
   - :p:`fls_twC8XhwbI60x`
 
+- Paragraphs changed to avoid referencing indirect terms:
+
+  - :p:`fls_xmgcdw9yhb55`
+  - :p:`fls_yeh6mvyvb4dp`
+  - :p:`fls_657knnsobdyu`
+  - :p:`fls_m942dwwmr2cl`
+  - :p:`fls_np33oqrz33mp`
+  - :p:`fls_atdpr8be2o2r`
+  - :p:`fls_fbgwb3pdfgz`
+  - :p:`fls_8tbxq95x06yt`
+  - :p:`fls_9oy9zo3x3fy3`
+  - :p:`fls_pdgj2xekdead`
+  - :p:`fls_4uoi6k8r7mvc`
+  - :p:`fls_fjaz4m90cagr`
+  - :p:`fls_eesn9kuylim`
+  - :p:`fls_ijfmnnrdlu8n`
+  - :p:`fls_6x7j9x354pkb`
+  - :p:`fls_h2cpbz2t74hy`
+  - :p:`fls_whj50spxz3bh`
+  - :p:`fls_d1cxq1zbt5fq`
+  - :p:`fls_48i245an2449`
+  - :p:`fls_69wr03rt0ali`
+  - :p:`fls_9d970yfwmj2d`
+  - :p:`fls_p9687v3xckps`
+  - :p:`fls_8j408kckzzud`
+
 Language changes in Rust 1.94.0
 -------------------------------
 

--- a/src/changelog.rst
+++ b/src/changelog.rst
@@ -19,6 +19,16 @@ with the change that has been applied due to it.
    just the language changes that had an impact to the FLS. See the `release
    notes`_ for a full list of changes.
 
+FLS maintenance
+---------------
+
+- Paragraphs added or changed to ensure all glossary terms are also found in the main text:
+
+  - :p:`fls_BBz4Iy7AeaU4`
+  - :p:`fls_cxNAtLSLjqbQ`
+  - :p:`fls_hyi2jnp38v1n`
+  - :p:`fls_twC8XhwbI60x`
+
 Language changes in Rust 1.94.0
 -------------------------------
 

--- a/src/changelog.rst
+++ b/src/changelog.rst
@@ -28,6 +28,8 @@ FLS maintenance
   - :p:`fls_cxNAtLSLjqbQ`
   - :p:`fls_hyi2jnp38v1n`
   - :p:`fls_twC8XhwbI60x`
+  - :p:`fls_9bp4cKSfW9A0`
+  - :p:`fls_Odh6Z7ivD1U4`
 
 - Paragraphs changed to avoid referencing indirect terms:
 

--- a/src/changelog.rst
+++ b/src/changelog.rst
@@ -29,6 +29,32 @@ FLS maintenance
   - :p:`fls_hyi2jnp38v1n`
   - :p:`fls_twC8XhwbI60x`
 
+- Paragraphs changed to avoid referencing indirect terms:
+
+  - :p:`fls_xmgcdw9yhb55`
+  - :p:`fls_yeh6mvyvb4dp`
+  - :p:`fls_657knnsobdyu`
+  - :p:`fls_m942dwwmr2cl`
+  - :p:`fls_np33oqrz33mp`
+  - :p:`fls_atdpr8be2o2r`
+  - :p:`fls_fbgwb3pdfgz`
+  - :p:`fls_8tbxq95x06yt`
+  - :p:`fls_9oy9zo3x3fy3`
+  - :p:`fls_pdgj2xekdead`
+  - :p:`fls_4uoi6k8r7mvc`
+  - :p:`fls_fjaz4m90cagr`
+  - :p:`fls_eesn9kuylim`
+  - :p:`fls_ijfmnnrdlu8n`
+  - :p:`fls_6x7j9x354pkb`
+  - :p:`fls_h2cpbz2t74hy`
+  - :p:`fls_whj50spxz3bh`
+  - :p:`fls_d1cxq1zbt5fq`
+  - :p:`fls_48i245an2449`
+  - :p:`fls_69wr03rt0ali`
+  - :p:`fls_9d970yfwmj2d`
+  - :p:`fls_p9687v3xckps`
+  - :p:`fls_8j408kckzzud`
+
 - Remove the term "indirection", and associated derivatives
 
   Changed glossary entries:

--- a/src/changelog.rst
+++ b/src/changelog.rst
@@ -57,6 +57,10 @@ FLS maintenance
   - :p:`fls_9d970yfwmj2d`
   - :p:`fls_p9687v3xckps`
   - :p:`fls_8j408kckzzud`
+  - :p:`fls_mdejdc0nNgyO`
+  - :p:`fls_WUCvCauUCmsD`
+  - :p:`fls_5SVthCNZBcVS`
+  - :p:`fls_SonodAQVL5J4`
 
 - Remove the term "indirection", and associated derivatives
 

--- a/src/changelog.rst
+++ b/src/changelog.rst
@@ -22,6 +22,13 @@ with the change that has been applied due to it.
 FLS maintenance
 ---------------
 
+- Paragraphs added or changed to ensure all glossary terms are also found in the main text:
+
+  - :p:`fls_BBz4Iy7AeaU4`
+  - :p:`fls_cxNAtLSLjqbQ`
+  - :p:`fls_hyi2jnp38v1n`
+  - :p:`fls_twC8XhwbI60x`
+
 - Remove the term "indirection", and associated derivatives
 
   Changed glossary entries:

--- a/src/entities-and-resolution.rst
+++ b/src/entities-and-resolution.rst
@@ -948,13 +948,7 @@ The :dt:`core prelude` is a :t:`prelude` that brings :t:`in scope` of every
 :std:`core::prelude::rust_2021` :t:`module`.
 
 :dp:`fls_atvnwly4w8g2`
-An :dt:`external prelude` is a :t:`prelude` that brings :t:`in scope` of the
-:t:`crate root module` the :t:`entities <entity>` of the :t:`[crate]s` imported
-using external :t:`[crate import]s` or supplied by a tool. If the external
-:t:`crate import` uses a :t:`renaming`, then the :t:`identifier` of the
-:t:`renaming` is instead added to the :t:`external prelude`. The core
-:t:`crate` is always added to the :t:`external prelude` unless the :t:`crate
-root module` is subject to :t:`attribute` ``no_core``.
+An :dt:`external prelude` is a :t:`prelude` that brings :t:`in scope` of the :t:`crate root module` the :t:`entities <entity>` of the :t:`[crate]s` imported using external :t:`[crate import]s` or supplied by a tool. If the external :t:`crate import` uses a :t:`renaming`, then the :t:`identifier` of the :t:`renaming` is instead added to the :t:`external prelude`. The core :t:`crate` is always added to the :t:`external prelude` unless the :t:`crate root module` is subject to :t:`attribute` ``no_core``.
 
 :dp:`fls_pbc7ktlu0pl`
 The :dt:`language prelude` is a :t:`prelude` that brings :t:`in scope` of every

--- a/src/entities-and-resolution.rst
+++ b/src/entities-and-resolution.rst
@@ -954,7 +954,7 @@ using external :t:`[crate import]s` or supplied by a tool. If the external
 :t:`crate import` uses a :t:`renaming`, then the :t:`identifier` of the
 :t:`renaming` is instead added to the :t:`external prelude`. The core
 :t:`crate` is always added to the :t:`external prelude` unless the :t:`crate
-root` is subject to :t:`attribute` ``no_core``.
+root module` is subject to :t:`attribute` ``no_core``.
 
 :dp:`fls_pbc7ktlu0pl`
 The :dt:`language prelude` is a :t:`prelude` that brings :t:`in scope` of every

--- a/src/expressions.rst
+++ b/src/expressions.rst
@@ -2606,60 +2606,60 @@ is used in the calculation of a :t:`compound assignment expression`.
 An :t:`assigned operand` shall denote a :t:`mutable assignee expression`.
 
 :dp:`fls_xmgcdw9yhb55`
-The :t:`type` of a :t:`compound assignment` is the :t:`unit type`.
+The :t:`type` of a :t:`compound assignment expression` is the :t:`unit type`.
 
 :dp:`fls_yeh6mvyvb4dp`
-The :t:`value` of a :t:`compound assignment` is the :t:`unit value`.
+The :t:`value` of a :t:`compound assignment expression` is the :t:`unit value`.
 
 :dp:`fls_657knnsobdyu`
-The :t:`type` of the :t:`assigned operand` of an :t:`addition assignment` shall
+The :t:`type` of the :t:`assigned operand` of an :t:`addition assignment expression` shall
 implement the :std:`core::ops::AddAssign` trait where the type of the right
 operand is the trait implementation type parameter.
 
 :dp:`fls_m942dwwmr2cl`
-The :t:`type` of the :t:`assigned operand` of a :t:`bit and assignment` shall
+The :t:`type` of the :t:`assigned operand` of a :t:`bit and assignment expression` shall
 implement the :std:`core::ops::BitAndAssign` :t:`trait` where the :t:`type` of
 the :t:`modifying operand` is the :t:`trait implementation` :t:`type parameter`.
 
 :dp:`fls_np33oqrz33mp`
-The :t:`type` of the :t:`assigned operand` of a :t:`bit or assignment` shall
+The :t:`type` of the :t:`assigned operand` of a :t:`bit or assignment expression` shall
 implement the :std:`core::ops::BitOrAssign` :t:`trait` where the :t:`type` of
 the :t:`modifying operand` is the :t:`trait implementation` :t:`type parameter`.
 
 :dp:`fls_atdpr8be2o2r`
-The :t:`type` of the :t:`assigned operand` of a :t:`bit xor assignment` shall
+The :t:`type` of the :t:`assigned operand` of a :t:`bit xor assignment expression` shall
 implement the :std:`core::ops::BitXorAssign` :t:`trait` where the :t:`type` of
 the :t:`modifying operand` is the :t:`trait implementation` :t:`type parameter`.
 
 :dp:`fls_fbgwb3pdfgz`
-The :t:`type` of the :t:`assigned operand` of a :t:`division assignment` shall
+The :t:`type` of the :t:`assigned operand` of a :t:`division assignment expression` shall
 implement the :std:`core::ops::DivAssign` :t:`trait` where the :t:`type` of the
 :t:`modifying operand` is the :t:`trait implementation` :t:`type parameter`.
 
 :dp:`fls_8tbxq95x06yt`
-The :t:`type` of the :t:`assigned operand` of a :t:`multiplication assignment`
+The :t:`type` of the :t:`assigned operand` of a :t:`multiplication assignment expression`
 shall implement the :std:`core::ops::MulAssign` :t:`trait` where the :t:`type`
 of the :t:`modifying operand` is the :t:`trait implementation`
 :t:`type parameter`.
 
 :dp:`fls_9oy9zo3x3fy3`
-The :t:`type` of the :t:`assigned operand` of a :t:`remainder assignment` shall
+The :t:`type` of the :t:`assigned operand` of a :t:`remainder assignment expression` shall
 implement the :std:`core::ops::RemAssign` :t:`trait` where the :t:`type` of the
 :t:`modifying operand` is the :t:`trait implementation` :t:`type parameter`.
 
 :dp:`fls_pdgj2xekdead`
-The :t:`type` of the :t:`assigned operand` of a :t:`shift left assignment` shall
+The :t:`type` of the :t:`assigned operand` of a :t:`shift left assignment expression` shall
 implement the :std:`core::ops::ShlAssign` :t:`trait` where the :t:`type` of the
 :t:`modifying operand` is the :t:`trait implementation` :t:`type parameter`.
 
 :dp:`fls_4uoi6k8r7mvc`
-The :t:`type` of the :t:`assigned operand` of a :t:`shift right assignment`
+The :t:`type` of the :t:`assigned operand` of a :t:`shift right assignment expression`
 shall implement the :std:`core::ops::ShrAssign` :t:`trait` where the :t:`type`
 of the :t:`modifying operand` is the :t:`trait implementation`
 :t:`type parameter`.
 
 :dp:`fls_fjaz4m90cagr`
-The :t:`type` of the :t:`assigned operand` of a :t:`subtraction assignment`
+The :t:`type` of the :t:`assigned operand` of a :t:`subtraction assignment expression`
 shall implement the :std:`core::ops::SubAssign` :t:`trait` where the :t:`type`
 of the :t:`modifying operand` is the :t:`trait implementation`
 :t:`type parameter`.
@@ -2667,7 +2667,7 @@ of the :t:`modifying operand` is the :t:`trait implementation`
 .. rubric:: Dynamic Semantics
 
 :dp:`fls_eesn9kuylim`
-The :t:`evaluation` of a :t:`compound assignment` proceeds as follows:
+The :t:`evaluation` of a :t:`compound assignment expression` proceeds as follows:
 
 #. :dp:`fls_4nnqz4etisgw`
    If the :t:`[type]s` of both :t:`[operand]s` are :t:`[integer type]s` or :t:`[floating-point type]s`, then
@@ -2694,52 +2694,52 @@ The :t:`evaluation` of a :t:`compound assignment` proceeds as follows:
       The appropriate :t:`function` is invoked as indicated below.
 
 :dp:`fls_ijfmnnrdlu8n`
-For an :t:`addition assignment`,
+For an :t:`addition assignment expression`,
 ``core::ops::AddAssign::add_assign(&mut assigned_operand, modifying_operand)``
 is invoked.
 
 :dp:`fls_6x7j9x354pkb`
-For a :t:`bit and assignment`,
+For a :t:`bit and assignment expression`,
 ``core::ops::BitAndAssign::bitand_assign(&mut assigned_operand, modifying_operand)``
 is invoked.
 
 :dp:`fls_h2cpbz2t74hy`
-For a :t:`bit or assignment`,
+For a :t:`bit or assignment expression`,
 ``core::ops::BitOrAssign::bitor_assign(&mut assigned_operand, modifying_operand)``
 is invoked.
 
 :dp:`fls_whj50spxz3bh`
-For a :t:`bit xor assignment`,
+For a :t:`bit xor assignment expression`,
 ``core::ops::BitXorAssign::bitxor_assign(&mut assigned_operand, modifying_operand)``
 is invoked.
 
 :dp:`fls_d1cxq1zbt5fq`
-For a :t:`division assignment`,
+For a :t:`division assignment expression`,
 ``core::ops::DivAssign::div_assign(&mut assigned_operand, modifying_operand)``
 is invoked.
 
 :dp:`fls_48i245an2449`
-For a :t:`multiplication assignment`,
+For a :t:`multiplication assignment expression`,
 ``core::ops::MulAssign::mul_assign(&mut assigned_operand, modifying_operand)``
 is invoked.
 
 :dp:`fls_69wr03rt0ali`
-For a :t:`remainder assignment`,
+For a :t:`remainder assignment expression`,
 ``core::ops::RemAssign::rem_assign(&mut assigned_operand, modifying_operand)``
 is invoked.
 
 :dp:`fls_9d970yfwmj2d`
-For a :t:`shift left assignment`,
+For a :t:`shift left assignment expression`,
 ``core::ops::ShlAssign::shl_assign(&mut assigned_operand, modifying_operand)``
 is invoked.
 
 :dp:`fls_p9687v3xckps`
-For a :t:`shift right assignment`,
+For a :t:`shift right assignment expression`,
 ``core::ops::ShrAssign::shr_assign(&mut assigned_operand, modifying_operand)``
 is invoked.
 
 :dp:`fls_8j408kckzzud`
-For a :t:`subtraction assignment`,
+For a :t:`subtraction assignment expression`,
 ``core::ops::SubAssign::sub_assign(&mut assigned_operand, modifying_operand)``
 is invoked.
 

--- a/src/expressions.rst
+++ b/src/expressions.rst
@@ -3562,6 +3562,9 @@ The :t:`evaluation` of a :t:`method call expression` proceeds as follows:
 Call Conformance
 ~~~~~~~~~~~~~~~~
 
+:dp:`fls_BBz4Iy7AeaU4`
+:dt:`Call conformance` measures the compatibility between a set of :t:`[argument operand]s` and a set of :t:`[function parameter]s` or :t:`[field]s`.
+
 :dp:`fls_tsn6SUUG9LvW`
 A :t:`method call expression` is equivalent to a :t:`call expression` where the
 :t:`call operand` is the resolved :t:`method` and the adjusted

--- a/src/general.rst
+++ b/src/general.rst
@@ -159,6 +159,9 @@ relevant to the topic:
 :dp:`fls_oxzjqxgejx9t`
 The syntax representation of a :t:`construct`.
 
+:dp:`fls_SonodAQVL5J4`
+A :dt:`construct` is a piece of program text that is an instance of a :t:`syntactic category`.
+
 .. rubric:: Legality Rules
 
 :dp:`fls_gmx688d6ek1o`
@@ -252,6 +255,9 @@ together with context-dependent requirements expressed by narrative rules.
 :dp:`fls_ioyp4wux6skt`
 The semantic meaning of a Rust program is described by means of narrative rules defining
 both the effects of each construct and the composition rules for constructs.
+
+:dp:`fls_5SVthCNZBcVS`
+A :dt:`syntactic category` is a nonterminal in the Backus-Naur Form grammar definition of the Rust programming language.
 
 :dp:`fls_jsflt7691ye4`
 The context-free syntax of Rust is described using a simple variant of the

--- a/src/generics.rst
+++ b/src/generics.rst
@@ -463,7 +463,7 @@ of the :t:`type parameter`.
   Any remaining :t:`[generic parameter]s` without corresponding conformant
   :t:`[generic argument]s` are :t:`[constant parameter]s` with
   :t:`[constant parameter initializer]s`, :t:`[lifetime parameter]s` with
-  either inferred :t:`[lifetime argument]s` or :t:`[elided lifetime]s`,
+  either inferred :t:`[lifetime argument]s` or :t:`elided lifetimes <lifetime elision>`,
   :t:`[type parameter]s` with :t:`[type parameter initializer]s` or inferred
   :t:`[type argument]s`, and
 

--- a/src/generics.rst
+++ b/src/generics.rst
@@ -123,8 +123,10 @@ A :t:`generic union` shall use all of its :t:`[type parameter]s` and
 :t:`[lifetime parameter]s` at least once in at least one of its :t:`[field]s`.
 
 :dp:`fls_hyi2jnp38v1n`
-A :t:`generic parameter` is said to constrain an :t:`implementation` if the
-:t:`generic parameter` appears at least once in one of the following:
+A :t:`generic parameter` is said to :dt:`constrain` an :t:`implementation` if it makes the applicability of the :t:`implementation` more narrow.
+
+:dp:`fls_cxNAtLSLjqbQ`
+A :t:`[constrain]t` happens when a :t:`generic parameter` appears at least once in one of the following:
 
 * :dp:`fls_sseo6u6pbcki`
   As a :t:`binding argument` in the :t:`[trait bound]s` of a :t:`type` that

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -4358,13 +4358,7 @@ A :dt:`textual type` is a :t:`type` class that includes type :c:`char` and type
 thin pointer
 ^^^^^^^^^^^^
 
-A :dt:`thin pointer` is a :t:`value` of a :t:`thin pointer type`.
-
-thin pointer type
-^^^^^^^^^^^^^^^^^
-
-A :dt:`thin pointer type` is an :t:`indirection type` that refers to a
-:t:`fixed sized type`.
+A :dt:`thin pointer` is a :t:`value` of  an :t:`indirection type` that refers to a :t:`fixed sized type`.
 
 token
 ^^^^^

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -98,12 +98,6 @@ anonymous return type
 An :dt:`anonymous return type` is an :t:`impl trait type` ascribed to a
 :t:`function` return type.
 
-anonymous type parameter
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-An :dt:`anonymous type parameter` is an :t:`impl trait type` ascribed to a
-:t:`function parameter`.
-
 any configuration predicate
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -383,11 +377,6 @@ async function
 ^^^^^^^^^^^^^^
 
 An :dt:`async function` is a :t:`function` subject to :t:`keyword` ``async``.
-
-atomic
-^^^^^^
-
-See :t:`atomic type`.
 
 atomic type
 ^^^^^^^^^^^
@@ -1046,11 +1035,6 @@ A :dt:`crate public modifier` is a :t:`visibility modifier` that grants a
 
 See :s:`CratePublicModifier`.
 
-crate root
-^^^^^^^^^^
-
-A :dt:`crate root` is an entry point into a :t:`crate`.
-
 crate root module
 ^^^^^^^^^^^^^^^^^
 
@@ -1387,11 +1371,6 @@ solidus), followed by the single character encoding of the special meaning
 character. For example, ``\t`` is the escaped character for 0x09 (horizontal
 tabulation).
 
-evaluated
-^^^^^^^^^
-
-See :t:`evaluation`.
-
 evaluation
 ^^^^^^^^^^
 
@@ -1405,11 +1384,6 @@ An :dt:`exclusive range pattern` is a :t:`range pattern` with both a
 :t:`range pattern low bound` and a :t:`range pattern high bound`.
 
 See :s:`ExclusiveRangePattern`.
-
-executed
-^^^^^^^^
-
-See :t:`execution`.
 
 execution
 ^^^^^^^^^
@@ -1513,11 +1487,6 @@ f64
 
 :dc:`f64` is a :t:`floating-point type` equivalent to the IEEE 754-2008
 binary64 :t:`type`.
-
-fat pointer
-^^^^^^^^^^^
-
-A :dt:`fat pointer` is a :t:`value` of a :t:`fat pointer type`.
 
 fat pointer type
 ^^^^^^^^^^^^^^^^
@@ -2016,12 +1985,6 @@ immutable static
 
 An :dt:`immutable static` is a :t:`static` whose :t:`value` cannot be modified.
 
-immutable variable
-^^^^^^^^^^^^^^^^^^
-
-An :dt:`immutable variable` is a :t:`variable` whose :t:`value` cannot be
-modified.
-
 impl header lifetime elision
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -2111,24 +2074,6 @@ An :dt:`inclusive range pattern` is a :t:`range pattern` with both a
 :t:`range pattern low bound` and a :t:`range pattern high bound`.
 
 See :s:`InclusiveRangePattern`.
-
-incomplete associated constant
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-An :dt:`incomplete associated constant` is an :t:`associated constant` without
-a :t:`constant initializer`.
-
-incomplete associated function
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-An :dt:`incomplete associated function` is an :t:`associated function` without
-a :t:`function body`.
-
-incomplete associated type
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-An :dt:`incomplete associated type` is an :t:`associated type` without an
-:t:`initialization type`.
 
 index expression
 ^^^^^^^^^^^^^^^^
@@ -2614,16 +2559,6 @@ local type
 
 A :dt:`local type` is a :t:`type` that is defined in the current :t:`crate`.
 
-local variable
-^^^^^^^^^^^^^^
-
-For :dt:`local variable`, see :t:`variable`.
-
-loop
-^^^^
-
-For :dt:`loop`, see :t:`loop expression`.
-
 loop body
 ^^^^^^^^^
 
@@ -3088,12 +3023,6 @@ object safe
 A :t:`trait` is :dt:`object safe` when it can be used as a
 :t:`trait object type`.
 
-object safety
-^^^^^^^^^^^^^
-
-:dt:`Object safety` is the process of determining whether a :t:`trait` can be
-used as a :t:`trait object type`.
-
 obsolete range pattern
 ^^^^^^^^^^^^^^^^^^^^^^
 
@@ -3339,12 +3268,6 @@ place expression context
 
 A :dt:`place expression context` is a :t:`construct` that may evaluate its
 operand as a memory location.
-
-plane
-^^^^^
-
-In :t:`Unicode`, a :dt:`plane` is a continuous group of 65,536
-:t:`[code point]s`.
 
 pointer
 ^^^^^^^
@@ -3672,11 +3595,6 @@ record struct type
 
 A :dt:`record struct type` is the :t:`type` of a :t:`record struct`.
 
-record struct value
-^^^^^^^^^^^^^^^^^^^
-
-A :dt:`record struct value` is a :t:`value` of a :t:`record struct type`.
-
 recursive type
 ^^^^^^^^^^^^^^
 
@@ -3845,11 +3763,6 @@ of times a :t:`macro repetition in matching` or a
 :t:`macro repetition in transcription` can be repeated.
 
 See :s:`MacroRepetitionOperator`.
-
-representation
-^^^^^^^^^^^^^^
-
-See :t:`type representation`.
 
 representation modifier
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -4777,11 +4690,6 @@ u128
 :dc:`u128` is an :t:`unsigned integer type` whose :t:`[value]s` range from 0 to
 2\ :sup:`128` - 1, all inclusive.
 
-unary operator
-^^^^^^^^^^^^^^
-
-A :dt:`unary operator` operates on one :t:`operand`.
-
 undefined behavior
 ^^^^^^^^^^^^^^^^^^
 
@@ -4887,16 +4795,6 @@ unit struct constant
 
 A :dt:`unit struct constant` is a :t:`constant` implicitly created by a
 :t:`unit struct`.
-
-unit struct type
-^^^^^^^^^^^^^^^^
-
-A :dt:`unit struct type` is the :t:`type` of a :t:`unit struct`.
-
-unit struct value
-^^^^^^^^^^^^^^^^^
-
-A :dt:`unit struct value` is a :t:`value` of a :t:`unit struct type`.
 
 unit tuple
 ^^^^^^^^^^
@@ -5167,11 +5065,6 @@ evaluate its :t:`loop body` as long as its :t:`subject let expression` yields a
 
 See :s:`WhileLetLoopExpression`.
 
-while loop
-^^^^^^^^^^
-
-For :dt:`while loop`, see :t:`while loop expression`.
-
 while loop expression
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -5186,11 +5079,6 @@ whitespace string
 
 A :dt:`whitespace string` is a string that consists of one or more
 :t:`[whitespace character]s`.
-
-zero-sized type
-^^^^^^^^^^^^^^^
-
-A :dt:`zero-sized type` is a :t:`fixed sized type` with :t:`size` zero.
 
 zero-variant enum type
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -4664,7 +4664,7 @@ For :dt:`unifiable`, see :t:`unify`.
 unifiable types
 ^^^^^^^^^^^^^^^
 
-Two :t:`[type]s` that :t:`unify` are said to be :dt:`[unifiable type]s`.
+Two :t:`[type]s` that :t:`unify` are said to be :dt:`unifiable types`.
 
 unified type
 ^^^^^^^^^^^^

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -1485,11 +1485,6 @@ A :dt:`field index` is the position of a :t:`field` within a
 
 See :s:`FieldIndex`.
 
-field list
-^^^^^^^^^^
-
-A :dt:`field list` is a :s:`RecordStructFieldList` or :s:`TupleStructFieldList`.
-
 field resolution
 ^^^^^^^^^^^^^^^^
 
@@ -4714,12 +4709,12 @@ A :dt:`unique immutable reference` is an :t:`immutable reference` produced by
 unit enum variant
 ^^^^^^^^^^^^^^^^^
 
-A :dt:`unit enum variant` is an :t:`enum variant` without a :t:`field list`.
+A :dt:`unit enum variant` is an :t:`enum variant` without a :s:`RecordStructFieldList` or :s:`TupleStructFieldList`.
 
 unit struct
 ^^^^^^^^^^^
 
-A :dt:`unit struct` is a :t:`struct` without a :t:`field list`.
+A :dt:`unit struct` is a :t:`struct` without a :s:`RecordStructFieldList` or a :s:`TupleStructFieldList`.
 
 See :s:`UnitStructDeclaration`.
 

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -46,11 +46,6 @@ active attribute
 An :dt:`active attribute` is an :t:`attribute` that is removed from the
 :t:`item` it decorates.
 
-addition assignment
-^^^^^^^^^^^^^^^^^^^
-
-For :dt:`addition assignment`, see :t:`addition assignment expression`.
-
 addition assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -232,11 +227,6 @@ An :dt:`assignee operand` is the target :t:`operand` of an
 :t:`assignment expression`.
 
 See :s:`AssigneeOperand`.
-
-assignment
-^^^^^^^^^^
-
-See :t:`assignment expression`.
 
 assignment expression
 ^^^^^^^^^^^^^^^^^^^^^
@@ -489,11 +479,6 @@ binding scope
 
 A :dt:`binding scope` is a :t:`scope` for :t:`[binding]s`.
 
-bit and assignment
-^^^^^^^^^^^^^^^^^^
-
-For :dt:`bit and assignment`, see :t:`bit and assignment expression`.
-
 bit and assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -518,11 +503,6 @@ two :t:`[operand]s` using bit arithmetic.
 
 See :s:`BitExpression`.
 
-bit or assignment
-^^^^^^^^^^^^^^^^^
-
-For :dt:`bit or assignment`, see :t:`bit or assignment expression`.
-
 bit or assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -537,11 +517,6 @@ bit or expression
 A :dt:`bit or expression` is a :t:`bit expression` that uses bit or arithmetic.
 
 See :s:`BitOrExpression`.
-
-bit xor assignment
-^^^^^^^^^^^^^^^^^^
-
-For :dt:`bit xor assignment`, see :t:`bit xor assignment expression`.
 
 bit xor assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -852,11 +827,6 @@ compilation root
 ^^^^^^^^^^^^^^^^
 
 A :dt:`compilation root` is an input to a compilation performed by a tool.
-
-compound assignment
-^^^^^^^^^^^^^^^^^^^
-
-For :dt:`compound assignment`, see :t:`compound assignment expression`.
 
 compound assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1193,11 +1163,6 @@ diverging type variable
 
 A :dt:`diverging type variable` is a :t:`type variable` that can refer to any
 :t:`type` and originates from a :t:`diverging expression`.
-
-division assignment
-^^^^^^^^^^^^^^^^^^^
-
-For :dt:`division assignment`, see :t:`division assignment expression`.
 
 division assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -2792,12 +2757,6 @@ multi segment path
 A :dt:`multi segment path` is a :t:`path` consisting of more than one
 :t:`path segment`.
 
-multiplication assignment
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-For :dt:`multiplication assignment`, see
-:t:`multiplication assignment expression`.
-
 multiplication assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -3719,11 +3678,6 @@ A :dt:`register parameter modifier` is a substring that starts with character
 0x3A (colon), follows a :t:`register parameter`, and changes the formatting of
 the related :t:`register parameter`.
 
-remainder assignment
-^^^^^^^^^^^^^^^^^^^^
-
-For :dt:`remainder assignment`, see :t:`remainder assignment expression`.
-
 remainder assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -3924,11 +3878,6 @@ shared reference type
 A :dt:`shared reference type` is a :t:`reference type` not subject to
 :t:`keyword` ``mut``.
 
-shift left assignment
-^^^^^^^^^^^^^^^^^^^^^
-
-For :dt:`shift left assignment`, see :t:`shift left assignment expression`.
-
 shift left assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -3944,11 +3893,6 @@ A :dt:`shift left expression` is a :t:`bit expression` that uses bit shift left
 arithmetic.
 
 See :s:`ShiftLeftExpression`.
-
-shift right assignment
-^^^^^^^^^^^^^^^^^^^^^^
-
-For :dt:`shift right assignment`, see :t:`shift right assignment expression`.
 
 shift right assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -4244,11 +4188,6 @@ subpattern
 ^^^^^^^^^^
 
 A :dt:`subpattern` is a :t:`pattern` nested within another :t:`pattern`.
-
-subtraction assignment
-^^^^^^^^^^^^^^^^^^^^^^
-
-For :dt:`subtraction assignment`, see :t:`subtraction assignment`.
 
 subtraction assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -4456,18 +4456,17 @@ thin pointer type
 A :dt:`thin pointer type` is an :t:`indirection type` that refers to a
 :t:`fixed sized type`.
 
+token
+^^^^^
+
+A :dt:`token` is a :t:`lexical element` that can be consumed by a :t:`macro`.
+
 token matching
 ^^^^^^^^^^^^^^
 
 :dt:`Token matching` is the process of consuming a :s:`TokenTree` in an attempt
 to fully satisfy a :t:`macro match` of a selected :t:`macro matcher` that
 belongs to a resolved :t:`declarative macro`.
-
-tokens
-^^^^^^
-
-:dt:`[Token]s` are a subset of :t:`[lexical element]s` consumed by
-:t:`[macro]s`.
 
 trait
 ^^^^^

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -716,9 +716,7 @@ See :s:`CStringLiteral`.
 Call conformance
 ^^^^^^^^^^^^^^^^
 
-:dt:`Call conformance` measures the compatibility between a set of
-:t:`[argument operand]s` and a set if :t:`[function parameter]s` or
-:t:`[field]s`.
+:dt:`Call conformance` measures the compatibility between a set of :t:`[argument operand]s` and a set of :t:`[function parameter]s` or :t:`[field]s`.
 
 call expression
 ^^^^^^^^^^^^^^^
@@ -977,8 +975,7 @@ into a :t:`constant`.
 constrain
 ^^^^^^^^^
 
-A :t:`generic parameter` is said to :dt:`constrain` an :t:`implementation` if
-it makes the :t:`[implementation]'s` applicability more narrow.
+A :t:`generic parameter` is said to :dt:`constrain` an :t:`implementation` if it makes the applicability of the :t:`implementation` more narrow.
 
 construct
 ^^^^^^^^^

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -1242,18 +1242,6 @@ a :t:`slice type`.
 
 See :s:`ElementType`.
 
-elided
-^^^^^^
-
-For :dt:`elided`, see :t:`elided lifetime`.
-
-elided lifetime
-^^^^^^^^^^^^^^^
-
-An :dt:`elided lifetime` is either an :t:`unnamed lifetime` or a :t:`lifetime`
-that has been explicitly omitted from a :t:`function signature` or an
-:t:`implementation`.
-
 else expression
 ^^^^^^^^^^^^^^^
 
@@ -4743,12 +4731,6 @@ unnamed constant
 ^^^^^^^^^^^^^^^^
 
 An :dt:`unnamed constant` is a :t:`constant` declared with character 0x5F (low
-line).
-
-unnamed lifetime
-^^^^^^^^^^^^^^^^
-
-An :dt:`unnamed lifetime` is a :t:`lifetime` declared with character 0x5F (low
 line).
 
 unqualified path expression

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -1488,11 +1488,6 @@ A :dt:`field index` is the position of a :t:`field` within a
 
 See :s:`FieldIndex`.
 
-field list
-^^^^^^^^^^
-
-A :dt:`field list` is a :s:`RecordStructFieldList` or :s:`TupleStructFieldList`.
-
 field resolution
 ^^^^^^^^^^^^^^^^
 
@@ -4768,12 +4763,12 @@ A :dt:`unique immutable reference` is an :t:`immutable reference` produced by
 unit enum variant
 ^^^^^^^^^^^^^^^^^
 
-A :dt:`unit enum variant` is an :t:`enum variant` without a :t:`field list`.
+A :dt:`unit enum variant` is an :t:`enum variant` without a :s:`RecordStructFieldList` or :s:`TupleStructFieldList`.
 
 unit struct
 ^^^^^^^^^^^
 
-A :dt:`unit struct` is a :t:`struct` without a :t:`field list`.
+A :dt:`unit struct` is a :t:`struct` without a :s:`RecordStructFieldList` or a :s:`TupleStructFieldList`.
 
 See :s:`UnitStructDeclaration`.
 

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -4504,18 +4504,17 @@ thin pointer type
 
 A :dt:`thin pointer type` is a :t:`pointer type` that refers to a :t:`fixed sized type`.
 
+token
+^^^^^
+
+A :dt:`token` is a :t:`lexical element` that can be consumed by a :t:`macro`.
+
 token matching
 ^^^^^^^^^^^^^^
 
 :dt:`Token matching` is the process of consuming a :s:`TokenTree` in an attempt
 to fully satisfy a :t:`macro match` of a selected :t:`macro matcher` that
 belongs to a resolved :t:`declarative macro`.
-
-tokens
-^^^^^^
-
-:dt:`[Token]s` are a subset of :t:`[lexical element]s` consumed by
-:t:`[macro]s`.
 
 trait
 ^^^^^

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -4718,7 +4718,7 @@ For :dt:`unifiable`, see :t:`unify`.
 unifiable types
 ^^^^^^^^^^^^^^^
 
-Two :t:`[type]s` that :t:`unify` are said to be :dt:`[unifiable type]s`.
+Two :t:`[type]s` that :t:`unify` are said to be :dt:`unifiable types`.
 
 unified type
 ^^^^^^^^^^^^

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -46,11 +46,6 @@ active attribute
 An :dt:`active attribute` is an :t:`attribute` that is removed from the
 :t:`item` it decorates.
 
-addition assignment
-^^^^^^^^^^^^^^^^^^^
-
-For :dt:`addition assignment`, see :t:`addition assignment expression`.
-
 addition assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -232,11 +227,6 @@ An :dt:`assignee operand` is the target :t:`operand` of an
 :t:`assignment expression`.
 
 See :s:`AssigneeOperand`.
-
-assignment
-^^^^^^^^^^
-
-See :t:`assignment expression`.
 
 assignment expression
 ^^^^^^^^^^^^^^^^^^^^^
@@ -489,11 +479,6 @@ binding scope
 
 A :dt:`binding scope` is a :t:`scope` for :t:`[binding]s`.
 
-bit and assignment
-^^^^^^^^^^^^^^^^^^
-
-For :dt:`bit and assignment`, see :t:`bit and assignment expression`.
-
 bit and assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -518,11 +503,6 @@ two :t:`[operand]s` using bit arithmetic.
 
 See :s:`BitExpression`.
 
-bit or assignment
-^^^^^^^^^^^^^^^^^
-
-For :dt:`bit or assignment`, see :t:`bit or assignment expression`.
-
 bit or assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -537,11 +517,6 @@ bit or expression
 A :dt:`bit or expression` is a :t:`bit expression` that uses bit or arithmetic.
 
 See :s:`BitOrExpression`.
-
-bit xor assignment
-^^^^^^^^^^^^^^^^^^
-
-For :dt:`bit xor assignment`, see :t:`bit xor assignment expression`.
 
 bit xor assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -852,11 +827,6 @@ compilation root
 ^^^^^^^^^^^^^^^^
 
 A :dt:`compilation root` is an input to a compilation performed by a tool.
-
-compound assignment
-^^^^^^^^^^^^^^^^^^^
-
-For :dt:`compound assignment`, see :t:`compound assignment expression`.
 
 compound assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1196,11 +1166,6 @@ diverging type variable
 
 A :dt:`diverging type variable` is a :t:`type variable` that can refer to any
 :t:`type` and originates from a :t:`diverging expression`.
-
-division assignment
-^^^^^^^^^^^^^^^^^^^
-
-For :dt:`division assignment`, see :t:`division assignment expression`.
 
 division assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -2842,12 +2807,6 @@ multi segment path
 A :dt:`multi segment path` is a :t:`path` consisting of more than one
 :t:`path segment`.
 
-multiplication assignment
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-For :dt:`multiplication assignment`, see
-:t:`multiplication assignment expression`.
-
 multiplication assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -3777,11 +3736,6 @@ A :dt:`register parameter modifier` is a substring that starts with character
 0x3A (colon), follows a :t:`register parameter`, and changes the formatting of
 the related :t:`register parameter`.
 
-remainder assignment
-^^^^^^^^^^^^^^^^^^^^
-
-For :dt:`remainder assignment`, see :t:`remainder assignment expression`.
-
 remainder assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -3982,11 +3936,6 @@ shared reference type
 A :dt:`shared reference type` is a :t:`reference type` not subject to
 :t:`keyword` ``mut``.
 
-shift left assignment
-^^^^^^^^^^^^^^^^^^^^^
-
-For :dt:`shift left assignment`, see :t:`shift left assignment expression`.
-
 shift left assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -4002,11 +3951,6 @@ A :dt:`shift left expression` is a :t:`bit expression` that uses bit shift left
 arithmetic.
 
 See :s:`ShiftLeftExpression`.
-
-shift right assignment
-^^^^^^^^^^^^^^^^^^^^^^
-
-For :dt:`shift right assignment`, see :t:`shift right assignment expression`.
 
 shift right assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -4293,11 +4237,6 @@ subpattern
 ^^^^^^^^^^
 
 A :dt:`subpattern` is a :t:`pattern` nested within another :t:`pattern`.
-
-subtraction assignment
-^^^^^^^^^^^^^^^^^^^^^^
-
-For :dt:`subtraction assignment`, see :t:`subtraction assignment`.
 
 subtraction assignment expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -1245,18 +1245,6 @@ a :t:`slice type`.
 
 See :s:`ElementType`.
 
-elided
-^^^^^^
-
-For :dt:`elided`, see :t:`elided lifetime`.
-
-elided lifetime
-^^^^^^^^^^^^^^^
-
-An :dt:`elided lifetime` is either an :t:`unnamed lifetime` or a :t:`lifetime`
-that has been explicitly omitted from a :t:`function signature` or an
-:t:`implementation`.
-
 else expression
 ^^^^^^^^^^^^^^^
 
@@ -4797,12 +4785,6 @@ unnamed constant
 ^^^^^^^^^^^^^^^^
 
 An :dt:`unnamed constant` is a :t:`constant` declared with character 0x5F (low
-line).
-
-unnamed lifetime
-^^^^^^^^^^^^^^^^
-
-An :dt:`unnamed lifetime` is a :t:`lifetime` declared with character 0x5F (low
 line).
 
 unqualified path expression

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -98,12 +98,6 @@ anonymous return type
 An :dt:`anonymous return type` is an :t:`impl trait type` ascribed to a
 :t:`function` return type.
 
-anonymous type parameter
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-An :dt:`anonymous type parameter` is an :t:`impl trait type` ascribed to a
-:t:`function parameter`.
-
 any configuration predicate
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -383,11 +377,6 @@ async function
 ^^^^^^^^^^^^^^
 
 An :dt:`async function` is a :t:`function` subject to :t:`keyword` ``async``.
-
-atomic
-^^^^^^
-
-See :t:`atomic type`.
 
 atomic type
 ^^^^^^^^^^^
@@ -1046,11 +1035,6 @@ A :dt:`crate public modifier` is a :t:`visibility modifier` that grants a
 
 See :s:`CratePublicModifier`.
 
-crate root
-^^^^^^^^^^
-
-A :dt:`crate root` is an entry point into a :t:`crate`.
-
 crate root module
 ^^^^^^^^^^^^^^^^^
 
@@ -1390,11 +1374,6 @@ solidus), followed by the single character encoding of the special meaning
 character. For example, ``\t`` is the escaped character for 0x09 (horizontal
 tabulation).
 
-evaluated
-^^^^^^^^^
-
-See :t:`evaluation`.
-
 evaluation
 ^^^^^^^^^^
 
@@ -1408,11 +1387,6 @@ An :dt:`exclusive range pattern` is a :t:`range pattern` with both a
 :t:`range pattern low bound` and a :t:`range pattern high bound`.
 
 See :s:`ExclusiveRangePattern`.
-
-executed
-^^^^^^^^
-
-See :t:`execution`.
 
 execution
 ^^^^^^^^^
@@ -1516,11 +1490,6 @@ f64
 
 :dc:`f64` is a :t:`floating-point type` equivalent to the IEEE 754-2008
 binary64 :t:`type`.
-
-fat pointer
-^^^^^^^^^^^
-
-A :dt:`fat pointer` is a :t:`value` of a :t:`fat pointer type`.
 
 fat pointer type
 ^^^^^^^^^^^^^^^^
@@ -2018,12 +1987,6 @@ immutable static
 
 An :dt:`immutable static` is a :t:`static` whose :t:`value` cannot be modified.
 
-immutable variable
-^^^^^^^^^^^^^^^^^^
-
-An :dt:`immutable variable` is a :t:`variable` whose :t:`value` cannot be
-modified.
-
 impl header lifetime elision
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -2113,24 +2076,6 @@ An :dt:`inclusive range pattern` is a :t:`range pattern` with both a
 :t:`range pattern low bound` and a :t:`range pattern high bound`.
 
 See :s:`InclusiveRangePattern`.
-
-incomplete associated constant
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-An :dt:`incomplete associated constant` is an :t:`associated constant` without
-a :t:`constant initializer`.
-
-incomplete associated function
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-An :dt:`incomplete associated function` is an :t:`associated function` without
-a :t:`function body`.
-
-incomplete associated type
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-An :dt:`incomplete associated type` is an :t:`associated type` without an
-:t:`initialization type`.
 
 index expression
 ^^^^^^^^^^^^^^^^
@@ -2611,16 +2556,6 @@ local type
 ^^^^^^^^^^
 
 A :dt:`local type` is a :t:`type` that is defined in the current :t:`crate`.
-
-local variable
-^^^^^^^^^^^^^^
-
-For :dt:`local variable`, see :t:`variable`.
-
-loop
-^^^^
-
-For :dt:`loop`, see :t:`loop expression`.
 
 loop body
 ^^^^^^^^^
@@ -3138,12 +3073,6 @@ object safe
 A :t:`trait` is :dt:`object safe` when it can be used as a
 :t:`trait object type`.
 
-object safety
-^^^^^^^^^^^^^
-
-:dt:`Object safety` is the process of determining whether a :t:`trait` can be
-used as a :t:`trait object type`.
-
 obsolete range pattern
 ^^^^^^^^^^^^^^^^^^^^^^
 
@@ -3393,12 +3322,6 @@ place expression context
 
 A :dt:`place expression context` is a :t:`construct` that may evaluate its
 operand as a memory location.
-
-plane
-^^^^^
-
-In :t:`Unicode`, a :dt:`plane` is a continuous group of 65,536
-:t:`[code point]s`.
 
 pointer
 ^^^^^^^
@@ -3730,11 +3653,6 @@ record struct type
 
 A :dt:`record struct type` is the :t:`type` of a :t:`record struct`.
 
-record struct value
-^^^^^^^^^^^^^^^^^^^
-
-A :dt:`record struct value` is a :t:`value` of a :t:`record struct type`.
-
 recursive type
 ^^^^^^^^^^^^^^
 
@@ -3903,11 +3821,6 @@ of times a :t:`macro repetition in matching` or a
 :t:`macro repetition in transcription` can be repeated.
 
 See :s:`MacroRepetitionOperator`.
-
-representation
-^^^^^^^^^^^^^^
-
-See :t:`type representation`.
 
 representation modifier
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -4825,11 +4738,6 @@ u128
 :dc:`u128` is an :t:`unsigned integer type` whose :t:`[value]s` range from 0 to
 2\ :sup:`128` - 1, all inclusive.
 
-unary operator
-^^^^^^^^^^^^^^
-
-A :dt:`unary operator` operates on one :t:`operand`.
-
 undefined behavior
 ^^^^^^^^^^^^^^^^^^
 
@@ -4935,16 +4843,6 @@ unit struct constant
 
 A :dt:`unit struct constant` is a :t:`constant` implicitly created by a
 :t:`unit struct`.
-
-unit struct type
-^^^^^^^^^^^^^^^^
-
-A :dt:`unit struct type` is the :t:`type` of a :t:`unit struct`.
-
-unit struct value
-^^^^^^^^^^^^^^^^^
-
-A :dt:`unit struct value` is a :t:`value` of a :t:`unit struct type`.
 
 unit tuple
 ^^^^^^^^^^
@@ -5220,11 +5118,6 @@ evaluate its :t:`loop body` as long as its :t:`subject let expression` yields a
 
 See :s:`WhileLetLoopExpression`.
 
-while loop
-^^^^^^^^^^
-
-For :dt:`while loop`, see :t:`while loop expression`.
-
 while loop expression
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -5239,11 +5132,6 @@ whitespace string
 
 A :dt:`whitespace string` is a string that consists of one or more
 :t:`[whitespace character]s`.
-
-zero-sized type
-^^^^^^^^^^^^^^^
-
-A :dt:`zero-sized type` is a :t:`fixed sized type` with :t:`size` zero.
 
 zero-variant enum type
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/src/inline-assembly.rst
+++ b/src/inline-assembly.rst
@@ -580,9 +580,7 @@ If a :t:`value` has a smaller size than the :t:`register` it is allocated in,
 then
 
 * :dp:`fls_drg7v8hxb5ca`
-  On RISC-V architectures, if the :t:`register` belongs to :t:`register class`
-  ``freg``, then :c:`f32` :t:`[value]s` are :t:`NaN-boxed <NaN-boxing>` in a
-  :c:`f64` :t:`value`.
+  On RISC-V architectures, if the :t:`register` belongs to :t:`register class` ``freg``, then :c:`f32` :t:`[value]s` are :t:`NaN-boxed <NaN-boxing>` in a :c:`f64` :t:`value`.
 
 * :dp:`fls_78gb8z1fyluc`
   Otherwise, for an :t:`input register`, the upper bits of the :t:`register`

--- a/src/inline-assembly.rst
+++ b/src/inline-assembly.rst
@@ -594,6 +594,7 @@ If a :t:`register argument` has :t:`direction modifier` ``inout`` and an
 :t:`input-output register expression`, then the :t:`input register expression`
 and the :t:`output register expression` shall have the same :t:`type`.
 
+:dp:`fls_FG0EmVgrDUDq`
 :dt:`NaN-boxing` is a technique for encoding :t:`[value]s` using the low order bits of the mantissa of a 64-bit IEEE floating-point ``NaN``.
 
 .. _fls_hejgghwzblf:

--- a/src/inline-assembly.rst
+++ b/src/inline-assembly.rst
@@ -596,6 +596,8 @@ If a :t:`register argument` has :t:`direction modifier` ``inout`` and an
 :t:`input-output register expression`, then the :t:`input register expression`
 and the :t:`output register expression` shall have the same :t:`type`.
 
+:dt:`NaN-boxing` is a technique for encoding :t:`[value]s` using the low order bits of the mantissa of a 64-bit IEEE floating-point ``NaN``.
+
 .. _fls_hejgghwzblf:
 
 Register Arguments

--- a/src/inline-assembly.rst
+++ b/src/inline-assembly.rst
@@ -581,7 +581,7 @@ then
 
 * :dp:`fls_drg7v8hxb5ca`
   On RISC-V architectures, if the :t:`register` belongs to :t:`register class`
-  ``freg``, then :c:`f32` :t:`[value]s` are :t:`NaN-boxed <NaN-boxing>`. in a
+  ``freg``, then :c:`f32` :t:`[value]s` are :t:`NaN-boxed <NaN-boxing>` in a
   :c:`f64` :t:`value`.
 
 * :dp:`fls_78gb8z1fyluc`

--- a/src/lexical-elements.rst
+++ b/src/lexical-elements.rst
@@ -1332,6 +1332,12 @@ A :t:`block comment` is a :t:`comment` that spans one or more :t:`[line]s`.
 :dp:`fls_nayisy85kyq2`
 A :t:`line comment` is a :t:`comment` that spans exactly one :t:`line`.
 
+:dp:`fls_5SVthCNZBcVS`
+A :dt:`syntactic category` is a nonterminal in the Backus-Naur Form grammar definition of the Rust programming language.
+
+:dp:`fls_SonodAQVL5J4`
+A :dt:`construct` is a piece of program text that is an instance of a :t:`syntactic category`.
+
 :dp:`fls_k3hj30hjkdhw`
 An :t:`inner block doc` is a :t:`block comment` that applies to an enclosing
 :t:`non-[comment]` :t:`construct`.
@@ -1560,4 +1566,3 @@ Word ``union`` acts as a :t:`keyword` only when used in the context of a
 
 :dp:`fls_g0JEluWqBpNc`
 Word ``safe`` acts as a :t:`keyword` only when used as a qualifier of :s:`FunctionDeclaration` or :s:`StaticDeclaration` in the context of a :s:`ExternalBlock`.
-

--- a/src/lexical-elements.rst
+++ b/src/lexical-elements.rst
@@ -1332,12 +1332,6 @@ A :t:`block comment` is a :t:`comment` that spans one or more :t:`[line]s`.
 :dp:`fls_nayisy85kyq2`
 A :t:`line comment` is a :t:`comment` that spans exactly one :t:`line`.
 
-:dp:`fls_5SVthCNZBcVS`
-A :dt:`syntactic category` is a nonterminal in the Backus-Naur Form grammar definition of the Rust programming language.
-
-:dp:`fls_SonodAQVL5J4`
-A :dt:`construct` is a piece of program text that is an instance of a :t:`syntactic category`.
-
 :dp:`fls_k3hj30hjkdhw`
 An :t:`inner block doc` is a :t:`block comment` that applies to an enclosing
 :t:`non-[comment]` :t:`construct`.

--- a/src/macros.rst
+++ b/src/macros.rst
@@ -25,7 +25,7 @@ distinct forms:
   return a stream of :t:`[lexical element]s`.
 
 :dp:`fls_rnty1c8l5495`
-:t:`[Token]s` are a subset of :t:`[lexical element]s` consumed by :t:`[macro]s`.
+A :dt:`token` is a :t:`lexical element` that can be consumed by a :t:`macro`.
 
 .. _fls_xa7lp0zg1ol2:
 
@@ -1113,4 +1113,3 @@ Every :t:`macro` has associated :t:`hygiene` that depends on its kind:
 :dp:`fls_7eqqk2cj0clr`
 The :t:`metavariable` ``$crate`` in a :t:`declarative macro`'s expansion refers
 to the crate the :t:`declarative macro` was declared in.
-

--- a/src/patterns.rst
+++ b/src/patterns.rst
@@ -88,7 +88,7 @@ restrictions:
 
 * :dp:`fls_kv533rntni1x`
   Any two :t:`[binding]s` with the same name in the two :t:`[pattern-without-alternation]s` shall have
-  :t:`[unifiable type]s` and shall have the same :t:`[binding mode]s`.
+  :t:`unifiable types` and shall have the same :t:`[binding mode]s`.
 
 .. _fls_uh76pw6ykd57:
 

--- a/src/patterns.rst
+++ b/src/patterns.rst
@@ -90,7 +90,7 @@ restrictions:
 
 * :dp:`fls_kv533rntni1x`
   Any two :t:`[binding]s` with the same name in the two :t:`[pattern-without-alternation]s` shall have
-  :t:`[unifiable type]s` and shall have the same :t:`[binding mode]s`.
+  :t:`unifiable types` and shall have the same :t:`[binding mode]s`.
 
 .. _fls_uh76pw6ykd57:
 

--- a/src/types-and-traits.rst
+++ b/src/types-and-traits.rst
@@ -767,6 +767,12 @@ Struct Types
 A :t:`struct type` is an :t:`abstract data type` that is a product of other
 :t:`[type]s`.
 
+:dp:`fls_mdejdc0nNgyO`
+A :dt:`record struct type` is the :t:`type` of a :t:`record struct`.
+
+:dp:`fls_WUCvCauUCmsD`
+A :dt:`record struct field` is a :t:`field` of a :t:`record struct type`.
+
 :dp:`fls_r885av95eivp`
 The :t:`name` of a :t:`record struct field` shall be unique within the
 related :s:`RecordStructDeclaration`.
@@ -3314,17 +3320,17 @@ An :dt:`output lifetime` is one of the following :t:`[lifetime]s`:
 :t:`Lifetime elision` proceeds as follows:
 
 #. :dp:`fls_1j204m1wy333`
-   Each :t:`elided` :t:`input lifetime` is a distinct :t:`lifetime parameter` in
+   Each :t:`elided <lifetime elision>` :t:`input lifetime` is a distinct :t:`lifetime parameter` in
    its related :t:`construct`.
 
 #. :dp:`fls_6km3cbchuxr2`
    If a :t:`construct` has exactly one :t:`input lifetime`, then that
-   :t:`lifetime` is assigned to all :t:`elided` :t:`[output lifetime]s`.
+   :t:`lifetime` is assigned to all :t:`elided <lifetime elision>` :t:`[output lifetime]s`.
 
 #. :dp:`fls_crb6m6b3cdwh`
    If a :t:`function` has a :t:`self parameter` with exactly 1
    :t:`self input lifetime`, then the :t:`lifetime` of the
-   :t:`self input lifetime` is assigned to all :t:`elided`
+   :t:`self input lifetime` is assigned to all :t:`elided <lifetime elision>`
    :t:`[output lifetime]s`.
 
 #. :dp:`fls_ac9tdlfwp5et`
@@ -3340,7 +3346,7 @@ Given :t:`function` ``f`` of the form
    fn f <'a, 'b, T: ToCStr>(&'a mut self, args: &'b [T]) -> &'a mut Command;
 
 :dp:`fls_vcmmkp9uruhr`
-its :t:`lifetime` :t:`elided` form is
+its :t:`lifetime` :t:`elided <lifetime elision>` form is
 
 .. code-block:: rust
 
@@ -3358,16 +3364,16 @@ Static Lifetime Elision
 the :t:`type ascription` of :t:`[constant]s` and :t:`[static]s`.
 
 :dp:`fls_8irr97rZWfSC`
-An :t:`elided` :t:`lifetime` of a :t:`reference type` or :t:`path` in the
+An :t:`elided <lifetime elision>` :t:`lifetime` of a :t:`reference type` or :t:`path` in the
 :t:`type specification` of a :t:`constant` or :t:`static` is inferred to be the
 ``'static'`` lifetime.
 
 :dp:`fls_37udexenqv3p`
 The :t:`lifetime` of an :t:`associated implementation constant` shall not be
-:t:`elided`.
+:t:`elided <lifetime elision>`.
 
 :dp:`fls_xi86he5vvill`
-The :t:`lifetime` of an :t:`associated trait constant` shall not be :t:`elided`.
+The :t:`lifetime` of an :t:`associated trait constant` shall not be :t:`elided <lifetime elision>`.
 
 .. rubric:: Examples
 
@@ -3379,7 +3385,7 @@ Given :t:`static` ``S`` of the form
    static S: &'static [&'static usize] = &[];
 
 :dp:`fls_f3yZ31dRuTPG`
-its :t:`lifetime` :t:`elided` form is
+its :t:`lifetime` :t:`elided <lifetime elision>` form is
 
 .. code-block:: rust
 
@@ -3397,12 +3403,12 @@ Trait Object Lifetime Elision
 applies to :t:`[trait object type]s`.
 
 :dp:`fls_URl9CeIVsiWs`
-An :t:`elided` :t:`lifetime` of a :t:`trait object type` is inferred as follows:
+An :t:`elided <lifetime elision>` :t:`lifetime` of a :t:`trait object type` is inferred as follows:
 
 * :dp:`fls_SHhw6lYHeYyQ`
   If the :t:`trait object type` is used as the :t:`type specification` of a
   :t:`reference type`, then the :t:`lifetime` of the :t:`reference type` is the
-  :t:`elided` :t:`lifetime`,
+  :t:`elided <lifetime elision>` :t:`lifetime`,
 
 * :dp:`fls_lC2rwdPLRwaf`
   If the :t:`trait object type` is used as a :t:`generic argument` and
@@ -3410,7 +3416,7 @@ An :t:`elided` :t:`lifetime` of a :t:`trait object type` is inferred as follows:
   * :dp:`fls_e36Hh4oJvfhv`
     if the corresponding :t:`generic parameter` has exactly one
     :t:`lifetime bound`, then the :t:`lifetime` of that :t:`bound` is the
-    :t:`elided` :t:`lifetime`,
+    :t:`elided <lifetime elision>` :t:`lifetime`,
 
   * :dp:`fls_ptejalcnIQtm`
     Otherwise it is a static error to infer the :t:`lifetime` :t:`bound`.
@@ -3422,8 +3428,8 @@ An :t:`elided` :t:`lifetime` of a :t:`trait object type` is inferred as follows:
 
 * :dp:`fls_JhmQpUoExiNZ`
   If the :t:`trait` of the :t:`trait object type` has no :t:`[lifetime bound]s`
-  specified, then the :t:`elided` :t:`lifetime` is the ``'static``
-  :t:`lifetime` unless it is :t:`elided` in :t:`[expression]s` where it is
+  specified, then the :t:`elided <lifetime elision>` :t:`lifetime` is the ``'static``
+  :t:`lifetime` unless it is :t:`elided <lifetime elision>` in :t:`[expression]s` where it is
   instead inferred,
 
 * :dp:`fls_cglZigwAnASl`
@@ -3439,7 +3445,7 @@ Given :t:`type alias` ``T`` of the form
    type T<'a> = &'a dyn Trait;
 
 :dp:`fls_YPesUZqYHVUX`
-its :t:`lifetime` :t:`elided` form is
+its :t:`lifetime` :t:`elided <lifetime elision>` form is
 
 .. code-block:: rust
 
@@ -3481,7 +3487,7 @@ Given an :t:`implementation` of the form
     impl Trait<&u8, Strukt<'_>> for &i32 {}
 
 :dp:`fls_w0vwdmO8qV9j`
-its :t:`lifetime` :t:`elided` form is
+its :t:`lifetime` :t:`elided <lifetime elision>` form is
 
 .. code-block:: rust
 

--- a/src/types-and-traits.rst
+++ b/src/types-and-traits.rst
@@ -696,6 +696,9 @@ It is a static error if the :t:`value` of a :t:`discriminant` exceeds the
 maximum :t:`value` of the :t:`type` of the :t:`expression` of a :t:`discriminant
 initializer`.
 
+:dp:`fls_Odh6Z7ivD1U4`
+A :dt:`unit enum variant` is an :t:`enum variant` without a :s:`RecordStructFieldList` or :s:`TupleStructFieldList`.
+
 .. rubric:: Undefined Behavior
 
 :dp:`fls_f046du2fkgr6`
@@ -777,6 +780,9 @@ the :s:`RecordStructFieldList`.
 If the :t:`type` of a :t:`tuple struct field` is a :t:`dynamically sized type`,
 then the :t:`tuple struct field` shall be the last :t:`tuple struct field` in
 the :s:`TupleStructFieldList`.
+
+:dp:`fls_9bp4cKSfW9A0`
+A :dt:`unit struct` is a :t:`struct` without a :s:`RecordStructFieldList` or a :s:`TupleStructFieldList`.
 
 .. rubric:: Examples
 

--- a/src/types-and-traits.rst
+++ b/src/types-and-traits.rst
@@ -1503,6 +1503,9 @@ share a common storage.
 :dp:`fls_njvdevz0xqc0`
 The :t:`size` of a :t:`recursive type` shall be finite.
 
+:dp:`fls_twC8XhwbI60x`
+A :dt:`thin pointer` is a :t:`value` of  an :t:`indirection type` that refers to a :t:`fixed sized type`.
+
 .. _fls_ohhsmifo0urd:
 
 Type Representation

--- a/src/types-and-traits.rst
+++ b/src/types-and-traits.rst
@@ -1764,7 +1764,7 @@ ranges, and structures of both :t:`[type]s` are compatible according to the
 rules detailed below.
 
 :dp:`fls_aie0tr62vhw5`
-Two types that :t:`unify` are said to be :t:`[unifiable type]s`.
+Two types that :t:`unify` are said to be :t:`unifiable types`.
 
 :dp:`fls_3U7Ue6Xzuv9M`
 :t:`Type unification` is a symmetric operation. If :t:`type` ``A`` unifies

--- a/src/types-and-traits.rst
+++ b/src/types-and-traits.rst
@@ -1742,7 +1742,7 @@ ranges, and structures of both :t:`[type]s` are compatible according to the
 rules detailed below.
 
 :dp:`fls_aie0tr62vhw5`
-Two types that :t:`unify` are said to be :t:`[unifiable type]s`.
+Two types that :t:`unify` are said to be :t:`unifiable types`.
 
 :dp:`fls_3U7Ue6Xzuv9M`
 :t:`Type unification` is a symmetric operation. If :t:`type` ``A`` unifies

--- a/src/types-and-traits.rst
+++ b/src/types-and-traits.rst
@@ -770,6 +770,9 @@ A :t:`struct type` is an :t:`abstract data type` that is a product of other
 :dp:`fls_mdejdc0nNgyO`
 A :dt:`record struct type` is the :t:`type` of a :t:`record struct`.
 
+:dp:`fls_9bp4cKSfW9A0`
+A :dt:`unit struct` is a :t:`struct` without a :s:`RecordStructFieldList` or a :s:`TupleStructFieldList`.
+
 :dp:`fls_WUCvCauUCmsD`
 A :dt:`record struct field` is a :t:`field` of a :t:`record struct type`.
 
@@ -786,9 +789,6 @@ the :s:`RecordStructFieldList`.
 If the :t:`type` of a :t:`tuple struct field` is a :t:`dynamically sized type`,
 then the :t:`tuple struct field` shall be the last :t:`tuple struct field` in
 the :s:`TupleStructFieldList`.
-
-:dp:`fls_9bp4cKSfW9A0`
-A :dt:`unit struct` is a :t:`struct` without a :s:`RecordStructFieldList` or a :s:`TupleStructFieldList`.
 
 .. rubric:: Examples
 

--- a/src/types-and-traits.rst
+++ b/src/types-and-traits.rst
@@ -767,6 +767,12 @@ Struct Types
 A :t:`struct type` is an :t:`abstract data type` that is a product of other
 :t:`[type]s`.
 
+:dp:`fls_mdejdc0nNgyO`
+A :dt:`record struct type` is the :t:`type` of a :t:`record struct`.
+
+:dp:`fls_WUCvCauUCmsD`
+A :dt:`record struct field` is a :t:`field` of a :t:`record struct type`.
+
 :dp:`fls_r885av95eivp`
 The :t:`name` of a :t:`record struct field` shall be unique within the
 related :s:`RecordStructDeclaration`.
@@ -3297,17 +3303,17 @@ An :dt:`output lifetime` is one of the following :t:`[lifetime]s`:
 :t:`Lifetime elision` proceeds as follows:
 
 #. :dp:`fls_1j204m1wy333`
-   Each :t:`elided` :t:`input lifetime` is a distinct :t:`lifetime parameter` in
+   Each :t:`elided <lifetime elision>` :t:`input lifetime` is a distinct :t:`lifetime parameter` in
    its related :t:`construct`.
 
 #. :dp:`fls_6km3cbchuxr2`
    If a :t:`construct` has exactly one :t:`input lifetime`, then that
-   :t:`lifetime` is assigned to all :t:`elided` :t:`[output lifetime]s`.
+   :t:`lifetime` is assigned to all :t:`elided <lifetime elision>` :t:`[output lifetime]s`.
 
 #. :dp:`fls_crb6m6b3cdwh`
    If a :t:`function` has a :t:`self parameter` with exactly 1
    :t:`self input lifetime`, then the :t:`lifetime` of the
-   :t:`self input lifetime` is assigned to all :t:`elided`
+   :t:`self input lifetime` is assigned to all :t:`elided <lifetime elision>`
    :t:`[output lifetime]s`.
 
 #. :dp:`fls_ac9tdlfwp5et`
@@ -3323,7 +3329,7 @@ Given :t:`function` ``f`` of the form
    fn f <'a, 'b, T: ToCStr>(&'a mut self, args: &'b [T]) -> &'a mut Command;
 
 :dp:`fls_vcmmkp9uruhr`
-its :t:`lifetime` :t:`elided` form is
+its :t:`lifetime` :t:`elided <lifetime elision>` form is
 
 .. code-block:: rust
 
@@ -3341,16 +3347,16 @@ Static Lifetime Elision
 the :t:`type ascription` of :t:`[constant]s` and :t:`[static]s`.
 
 :dp:`fls_8irr97rZWfSC`
-An :t:`elided` :t:`lifetime` of a :t:`reference type` or :t:`path` in the
+An :t:`elided <lifetime elision>` :t:`lifetime` of a :t:`reference type` or :t:`path` in the
 :t:`type specification` of a :t:`constant` or :t:`static` is inferred to be the
 ``'static'`` lifetime.
 
 :dp:`fls_37udexenqv3p`
 The :t:`lifetime` of an :t:`associated implementation constant` shall not be
-:t:`elided`.
+:t:`elided <lifetime elision>`.
 
 :dp:`fls_xi86he5vvill`
-The :t:`lifetime` of an :t:`associated trait constant` shall not be :t:`elided`.
+The :t:`lifetime` of an :t:`associated trait constant` shall not be :t:`elided <lifetime elision>`.
 
 .. rubric:: Examples
 
@@ -3362,7 +3368,7 @@ Given :t:`static` ``S`` of the form
    static S: &'static [&'static usize] = &[];
 
 :dp:`fls_f3yZ31dRuTPG`
-its :t:`lifetime` :t:`elided` form is
+its :t:`lifetime` :t:`elided <lifetime elision>` form is
 
 .. code-block:: rust
 
@@ -3380,12 +3386,12 @@ Trait Object Lifetime Elision
 applies to :t:`[trait object type]s`.
 
 :dp:`fls_URl9CeIVsiWs`
-An :t:`elided` :t:`lifetime` of a :t:`trait object type` is inferred as follows:
+An :t:`elided <lifetime elision>` :t:`lifetime` of a :t:`trait object type` is inferred as follows:
 
 * :dp:`fls_SHhw6lYHeYyQ`
   If the :t:`trait object type` is used as the :t:`type specification` of a
   :t:`reference type`, then the :t:`lifetime` of the :t:`reference type` is the
-  :t:`elided` :t:`lifetime`,
+  :t:`elided <lifetime elision>` :t:`lifetime`,
 
 * :dp:`fls_lC2rwdPLRwaf`
   If the :t:`trait object type` is used as a :t:`generic argument` and
@@ -3393,7 +3399,7 @@ An :t:`elided` :t:`lifetime` of a :t:`trait object type` is inferred as follows:
   * :dp:`fls_e36Hh4oJvfhv`
     if the corresponding :t:`generic parameter` has exactly one
     :t:`lifetime bound`, then the :t:`lifetime` of that :t:`bound` is the
-    :t:`elided` :t:`lifetime`,
+    :t:`elided <lifetime elision>` :t:`lifetime`,
 
   * :dp:`fls_ptejalcnIQtm`
     Otherwise it is a static error to infer the :t:`lifetime` :t:`bound`.
@@ -3405,8 +3411,8 @@ An :t:`elided` :t:`lifetime` of a :t:`trait object type` is inferred as follows:
 
 * :dp:`fls_JhmQpUoExiNZ`
   If the :t:`trait` of the :t:`trait object type` has no :t:`[lifetime bound]s`
-  specified, then the :t:`elided` :t:`lifetime` is the ``'static``
-  :t:`lifetime` unless it is :t:`elided` in :t:`[expression]s` where it is
+  specified, then the :t:`elided <lifetime elision>` :t:`lifetime` is the ``'static``
+  :t:`lifetime` unless it is :t:`elided <lifetime elision>` in :t:`[expression]s` where it is
   instead inferred,
 
 * :dp:`fls_cglZigwAnASl`
@@ -3422,7 +3428,7 @@ Given :t:`type alias` ``T`` of the form
    type T<'a> = &'a dyn Trait;
 
 :dp:`fls_YPesUZqYHVUX`
-its :t:`lifetime` :t:`elided` form is
+its :t:`lifetime` :t:`elided <lifetime elision>` form is
 
 .. code-block:: rust
 
@@ -3464,7 +3470,7 @@ Given an :t:`implementation` of the form
     impl Trait<&u8, Strukt<'_>> for &i32 {}
 
 :dp:`fls_w0vwdmO8qV9j`
-its :t:`lifetime` :t:`elided` form is
+its :t:`lifetime` :t:`elided <lifetime elision>` form is
 
 .. code-block:: rust
 

--- a/src/types-and-traits.rst
+++ b/src/types-and-traits.rst
@@ -645,6 +645,9 @@ A :t:`zero-variant enum type` has no :t:`[value]s`.
 An :t:`enum variant` is a :t:`construct` that declares one of the
 possible variations of an :t:`enum`.
 
+:dp:`fls_Odh6Z7ivD1U4`
+A :dt:`unit enum variant` is an :t:`enum variant` without a :s:`RecordStructFieldList` or :s:`TupleStructFieldList`.
+
 :dp:`fls_g5qle7xzaoif`
 The :t:`name` of an :t:`enum variant` shall be unique within the related
 :s:`EnumDeclaration`.
@@ -695,9 +698,6 @@ with the same :t:`value`.
 It is a static error if the :t:`value` of a :t:`discriminant` exceeds the
 maximum :t:`value` of the :t:`type` of the :t:`expression` of a :t:`discriminant
 initializer`.
-
-:dp:`fls_Odh6Z7ivD1U4`
-A :dt:`unit enum variant` is an :t:`enum variant` without a :s:`RecordStructFieldList` or :s:`TupleStructFieldList`.
 
 .. rubric:: Undefined Behavior
 

--- a/src/types-and-traits.rst
+++ b/src/types-and-traits.rst
@@ -1125,8 +1125,10 @@ An :t:`impl trait type` is a :t:`type` that implements a :t:`trait`, where the
 :t:`type` is known at compile time.
 
 :dp:`fls_ieyqx5vzas2m`
-An :t:`impl trait type` shall appear only within a :t:`function parameter` or
-the :t:`return type` of a :t:`function`.
+An :t:`impl trait type` is either an :t:`anonymous type parameter` or an :t:`anonymous return type`.
+
+:dp:`fls_EyvBbFdFHWwo`
+An :dt:`anonymous type parameter` is an :t:`impl trait type` ascribed to a :t:`function parameter`.
 
 :dp:`fls_3aKZB0ILIkZw`
 An :t:`anonymous return type` is an :t:`impl trait type` ascribed to a

--- a/src/values.rst
+++ b/src/values.rst
@@ -142,7 +142,7 @@ A :t:`pointer` is :t:`dangling` if it is either :c:`null` or not all of the byte
 A :t:`thin pointer` is a :t:`value` of a :t:`thin pointer type`.
 
 :dp:`fls_qpARFqqnKGMn`
-A :t:`fat pointer` is a :t:`value` of a :t:`fat pointer type`.
+A :dt:`fat pointer` is a :t:`value` of a :t:`fat pointer type`.
 
 :dp:`fls_VWUlxTy0QF9d`
 An :t:`original pointer` is a :t:`pointer` created via allocation.


### PR DESCRIPTION
*It will be more easy to review commits individually.*

This is part of https://github.com/rust-lang/fls/issues/680, and a number of fixes and improvements (I think) were made along the way.

The one commit am not so sure of is bd6ab3fea72f789b5e8ff11161004fe1bbd2aa17... I can imagine doing it differently, but am not sure it that will make the diff smaller.
