### PR TITLE
Remove term "indirection" and its derivatives

### DIFF
--- a/src/changelog.rst
+++ b/src/changelog.rst
@@ -22,7 +22,7 @@ with the change that has been applied due to it.
 FLS maintenance
 ---------------
 
-- `[Change]: Remove the term "indirection", and associated derivatives <https://github.com/rust-lang/fls/issues/710>`_
+- `Remove the term "indirection", and associated derivatives <https://github.com/rust-lang/fls/issues/710>`_
 
   Changed glossary entries:
 
@@ -43,19 +43,9 @@ FLS maintenance
   - :p:`fls_jrohsv7hx7yw`
   - :p:`fls_3qI8FXMsyk0f`
   - :p:`fls_rpbhr0xukbx9`
-  - :p:`fls_8uWfFAsZeRCs`
   - :p:`fls_twhq24s8kchh`
-  - :p:`fls_w4NbA7WhZfR2`
-  - :p:`fls_ie0avzljmxfm`
   - :p:`fls_15zdiqsm1q3p`
-  - :p:`fls_GUZuiST7ucib`
-  - :p:`fls_vaas9kns4zo6`
-  - :p:`fls_n6ffcms5pr0r`
-  - :p:`fls_26Xgem831Nqg`
   - :p:`fls_ozYgHEHFTT5c`
-  - :p:`fls_18ke90udyp67`
-  - :p:`fls_nrqG8i3fmpm4`
-  - :p:`fls_e5hivr6m5s3h`
 
   Moved paragraphs:
 

--- a/src/changelog.rst
+++ b/src/changelog.rst
@@ -22,7 +22,7 @@ with the change that has been applied due to it.
 FLS maintenance
 ---------------
 
-- `Remove the term "indirection", and associated derivatives <https://github.com/rust-lang/fls/issues/710>`_
+- Remove the term "indirection", and associated derivatives
 
   Changed glossary entries:
 

--- a/src/changelog.rst
+++ b/src/changelog.rst
@@ -19,6 +19,13 @@ with the change that has been applied due to it.
    just the language changes that had an impact to the FLS. See the `release
    notes`_ for a full list of changes.
 
+FLS maintenance
+---------------
+
+- `[Change]: Remove the term "indirection", and associated derivatives <https://github.com/rust-lang/fls/issues/710>`_
+
+  TODO: Update when things settle.
+
 Language changes in Rust 1.98.0
 -------------------------------
 
@@ -119,7 +126,7 @@ Language changes in Rust 1.95.0
 
   - :t:`let binding`
 
-  Changed existing paragraphs:
+  Changed paragraphs:
 
   - :p:`fls_72JHo343O7jp`
   - :p:`fls_6bwTtGKb7ba7`

--- a/src/changelog.rst
+++ b/src/changelog.rst
@@ -24,7 +24,84 @@ FLS maintenance
 
 - `[Change]: Remove the term "indirection", and associated derivatives <https://github.com/rust-lang/fls/issues/710>`_
 
-  TODO: Update when things settle.
+  Changed glossary entries:
+
+  - :t:`dangling`
+  - :t:`fat pointer type`
+  - :t:`function pointer type`
+  - :t:`pointer type`
+  - :t:`raw pointer type`
+  - :t:`reference type`
+  - :t:`thin pointer type`
+
+  Removed glossary entries:
+
+  - indirection type
+
+  Changed paragraphs:
+
+  - :p:`fls_jrohsv7hx7yw`
+  - :p:`fls_3qI8FXMsyk0f`
+  - :p:`fls_rpbhr0xukbx9`
+  - :p:`fls_8uWfFAsZeRCs`
+  - :p:`fls_twhq24s8kchh`
+  - :p:`fls_w4NbA7WhZfR2`
+  - :p:`fls_ie0avzljmxfm`
+  - :p:`fls_15zdiqsm1q3p`
+  - :p:`fls_GUZuiST7ucib`
+  - :p:`fls_vaas9kns4zo6`
+  - :p:`fls_n6ffcms5pr0r`
+  - :p:`fls_26Xgem831Nqg`
+  - :p:`fls_ozYgHEHFTT5c`
+  - :p:`fls_18ke90udyp67`
+  - :p:`fls_nrqG8i3fmpm4`
+  - :p:`fls_e5hivr6m5s3h`
+
+  Moved paragraphs:
+
+  - :p:`fls_1kg1mknf4yx7`
+  - :p:`fls_v2wrytr3t04h`
+  - :p:`fls_5dd7icjcl3nt`
+  - :p:`fls_B0SMXRqQMS1E`
+  - :p:`fls_hbn1l42xmr3h`
+  - :p:`fls_g1iYVw7upBnH`
+  - :p:`fls_8gpvNJfVlyaD`
+  - :p:`fls_KcI6yK0P8Onn`
+  - :p:`fls_52thmi9hnoks`
+  - :p:`fls_bYWfGDAQcWfA`
+  - :p:`fls_c2Guy3fPYaUV`
+  - :p:`fls_hrum767l6dte`
+  - :p:`fls_k6ues2936pjq`
+  - :p:`fls_csdjfwczlzfd`
+  - :p:`fls_ezh8aq6fmdvz`
+  - :p:`fls_jriT46yWgIR0`
+  - :p:`fls_VWUlxTy0QF9d`
+  - :p:`fls_kaPNJ7iIHPro`
+  - :p:`fls_5MkKtNL9oCsL`
+  - :p:`fls_1NJhTBN1D2qv`
+  - :p:`fls_wnJmQYT7iKQf`
+  - :p:`fls_ffh8mAkebORJ`
+  - :p:`fls_c3DaCLQEBpYQ`
+
+  New paragraphs:
+
+  - :p:`fls_Im7miUSS87xs`
+  - :p:`fls_aQgOFrzAhdsC`
+
+  Changed sections:
+
+  - :ref:`fls_3i4ou0dq64ny`
+
+  Moved sections:
+
+  - :ref:`fls_xztr1kebz8bo`
+  - :ref:`fls_Dqk4eIvxHloY`
+
+  New sections:
+
+  - :ref:`fls_xOuhiItK1hK0`
+  - :ref:`fls_qPWQnNXH52R3`
+  - :ref:`fls_phgP8YIwpXpi`
 
 Language changes in Rust 1.98.0
 -------------------------------

--- a/src/changelog.rst
+++ b/src/changelog.rst
@@ -19,6 +19,44 @@ with the change that has been applied due to it.
    just the language changes that had an impact to the FLS. See the `release
    notes`_ for a full list of changes.
 
+FLS maintenance
+---------------
+
+- `[Change]: Remove the term "indirection", and associated derivatives <https://github.com/rust-lang/fls/issues/710>`_
+
+  Changed glossary entries:
+
+  - :t:`dangling`
+  - :t:`fat pointer type`
+  - :t:`function pointer type`
+  - :t:`pointer type`
+  - :t:`raw pointer type`
+  - :t:`reference type`
+  - :t:`thin pointer type`
+
+  Removed glossary entries:
+
+  - :t:`indirection type`
+
+  New paragraphs:
+
+  - :p:`fls_f3TcmFrVoNis`
+  - :p:`fls_8RBNIR0E6pnI`
+  - :p:`fls_Im7miUSS87xs`
+  - :p:`fls_aQgOFrzAhdsC`
+
+  Changed paragraphs:
+
+  - :p:`fls_jrohsv7hx7yw`
+  - :p:`fls_3qI8FXMsyk0f`
+  - :p:`fls_v2wrytr3t04h`
+  - :p:`fls_rpbhr0xukbx9`
+  - :p:`fls_twhq24s8kchh`
+  - :p:`fls_26Xgem831Nqg`
+  - :p:`fls_ozYgHEHFTT5c`
+
+  Changed section :ref:`fls_3i4ou0dq64ny`
+
 Language changes in Rust 1.96.0
 -------------------------------
 
@@ -76,7 +114,7 @@ Language changes in Rust 1.95.0
 
   - :t:`let binding`
 
-  Changed existing paragraphs:
+  Changed paragraphs:
 
   - :p:`fls_72JHo343O7jp`
   - :p:`fls_6bwTtGKb7ba7`

--- a/src/dev-guide.rst
+++ b/src/dev-guide.rst
@@ -79,7 +79,7 @@ Use the following sentence pattern for multiple sections::
     - :ref:`fls_section_id`
     - :ref:`fls_section_id`
 
-``<Action>`` must denote either ``Moved``, ``New``, or ``Removed``.
+``<Action>`` must denote either ``Changed``, ``Moved``, ``New``, or ``Removed``.
 
 Syntax
 ~~~~~~

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -1070,9 +1070,7 @@ the tool compiling the :t:`crate`.
 dangling
 ^^^^^^^^
 
-A :t:`value` of an :t:`indirection type` is :dt:`dangling` if it is either
-:c:`null` or not all of the bytes at the referred memory location are part of
-the same allocation.
+A :t:`pointer` is :dt:`dangling` if it is either :c:`null` or not all of the bytes at the referred memory location are part of the same allocation.
 
 data race
 ^^^^^^^^^
@@ -1530,7 +1528,7 @@ A :dt:`fat pointer` is a :t:`value` of a :t:`fat pointer type`.
 fat pointer type
 ^^^^^^^^^^^^^^^^
 
-A :dt:`fat pointer type` is an :t:`indirection type` whose contained :t:`type specification` is a :t:`dynamically sized type`.
+A :dt:`fat pointer type` is a :t:`pointer type` whose contained :t:`type specification` is a :t:`dynamically sized type`.
 
 FFI
 ^^^
@@ -1699,8 +1697,7 @@ See :s:`FunctionParameter`.
 function pointer type
 ^^^^^^^^^^^^^^^^^^^^^
 
-A :dt:`function pointer type` is an :t:`indirection type` that refers to a
-:t:`function`.
+A :dt:`function pointer type` is a :t:`type` that refers to a :t:`function`.
 
 See :s:`FunctionPointerTypeSpecification`.
 
@@ -2191,12 +2188,6 @@ An :dt:`indexing operand` is an :t:`operand` which specifies the index for the
 :t:`indexed operand` being indexed into by an :t:`index expression`.
 
 See :s:`IndexingOperand`.
-
-indirection type
-^^^^^^^^^^^^^^^^
-
-An :dt:`indirection type` is a :t:`type` whose :t:`[value]s` refer to memory
-locations.
 
 inert attribute
 ^^^^^^^^^^^^^^^
@@ -3420,7 +3411,7 @@ A :dt:`pointer` is a :t:`value` of a :t:`pointer type`.
 pointer type
 ^^^^^^^^^^^^
 
-A :dt:`pointer type` is either a :t:`raw pointer type` or a :t:`reference type`.
+A :dt:`pointer type` is a :t:`type` whose :t:`[value]s` refer to memory locations.
 
 positional register argument
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -3678,8 +3669,7 @@ A :dt:`raw pointer` is a :t:`value` of a :t:`raw pointer type`.
 raw pointer type
 ^^^^^^^^^^^^^^^^
 
-A :dt:`raw pointer type` is an :t:`indirection type` without safety and
-liveness guarantees.
+A :dt:`raw pointer type` is a :t:`pointer type` without safety and liveness guarantees.
 
 See :s:`RawPointerTypeSpecification`.
 
@@ -3776,7 +3766,7 @@ See :s:`ReferencePattern`.
 reference type
 ^^^^^^^^^^^^^^
 
-A :dt:`reference type` is an :t:`indirection type` with :t:`ownership`.
+A :dt:`reference type` is a :t:`pointer type` with :t:`ownership`.
 
 See :s:`ReferenceTypeSpecification`.
 
@@ -4512,8 +4502,7 @@ A :dt:`thin pointer` is a :t:`value` of a :t:`thin pointer type`.
 thin pointer type
 ^^^^^^^^^^^^^^^^^
 
-A :dt:`thin pointer type` is an :t:`indirection type` that refers to a
-:t:`fixed sized type`.
+A :dt:`thin pointer type` is a :t:`pointer type` that refers to a :t:`fixed sized type`.
 
 token matching
 ^^^^^^^^^^^^^^

--- a/src/glossary.rst
+++ b/src/glossary.rst
@@ -1070,9 +1070,7 @@ the tool compiling the :t:`crate`.
 dangling
 ^^^^^^^^
 
-A :t:`value` of an :t:`indirection type` is :dt:`dangling` if it is either
-:c:`null` or not all of the bytes at the referred memory location are part of
-the same allocation.
+A :t:`pointer` is :dt:`dangling` if it is either :c:`null` or not all of the bytes at the referred memory location are part of the same allocation.
 
 data race
 ^^^^^^^^^
@@ -1530,7 +1528,7 @@ A :dt:`fat pointer` is a :t:`value` of a :t:`fat pointer type`.
 fat pointer type
 ^^^^^^^^^^^^^^^^
 
-A :dt:`fat pointer type` is an :t:`indirection type` whose contained :t:`type specification` is a :t:`dynamically sized type`.
+A :dt:`fat pointer type` is a :t:`pointer type` whose contained :t:`type specification` is a :t:`dynamically sized type`.
 
 FFI
 ^^^
@@ -1699,8 +1697,7 @@ See :s:`FunctionParameter`.
 function pointer type
 ^^^^^^^^^^^^^^^^^^^^^
 
-A :dt:`function pointer type` is an :t:`indirection type` that refers to a
-:t:`function`.
+A :dt:`function pointer type` is a :t:`pointer type` that refers to a :t:`function`.
 
 See :s:`FunctionPointerTypeSpecification`.
 
@@ -2191,12 +2188,6 @@ An :dt:`indexing operand` is an :t:`operand` which specifies the index for the
 :t:`indexed operand` being indexed into by an :t:`index expression`.
 
 See :s:`IndexingOperand`.
-
-indirection type
-^^^^^^^^^^^^^^^^
-
-An :dt:`indirection type` is a :t:`type` whose :t:`[value]s` refer to memory
-locations.
 
 inert attribute
 ^^^^^^^^^^^^^^^
@@ -3420,7 +3411,7 @@ A :dt:`pointer` is a :t:`value` of a :t:`pointer type`.
 pointer type
 ^^^^^^^^^^^^
 
-A :dt:`pointer type` is either a :t:`raw pointer type` or a :t:`reference type`.
+A :dt:`pointer type` is a :t:`type` whose :t:`[value]s` refer to memory locations.
 
 positional register argument
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -3678,8 +3669,7 @@ A :dt:`raw pointer` is a :t:`value` of a :t:`raw pointer type`.
 raw pointer type
 ^^^^^^^^^^^^^^^^
 
-A :dt:`raw pointer type` is an :t:`indirection type` without safety and
-liveness guarantees.
+A :dt:`raw pointer type` is a :t:`pointer type` without safety and liveness guarantees.
 
 See :s:`RawPointerTypeSpecification`.
 
@@ -3776,7 +3766,7 @@ See :s:`ReferencePattern`.
 reference type
 ^^^^^^^^^^^^^^
 
-A :dt:`reference type` is an :t:`indirection type` with :t:`ownership`.
+A :dt:`reference type` is a :t:`pointer type` with :t:`ownership`.
 
 See :s:`ReferenceTypeSpecification`.
 
@@ -4512,8 +4502,7 @@ A :dt:`thin pointer` is a :t:`value` of a :t:`thin pointer type`.
 thin pointer type
 ^^^^^^^^^^^^^^^^^
 
-A :dt:`thin pointer type` is an :t:`indirection type` that refers to a
-:t:`fixed sized type`.
+A :dt:`thin pointer type` is a :t:`pointer type` that refers to a :t:`fixed sized type`.
 
 token matching
 ^^^^^^^^^^^^^^

--- a/src/types-and-traits.rst
+++ b/src/types-and-traits.rst
@@ -120,7 +120,7 @@ Type Classification
     :t:`[Function item type]s`
 
 * :dp:`fls_jrohsv7hx7yw`
-  :t:`[Indirection type]s`
+  :t:`[Pointer type]s`
 
   * :dp:`fls_1kg1mknf4yx7`
     :t:`[Function pointer type]s`
@@ -936,13 +936,19 @@ A :t:`function item type` implements the :std:`core::ops::Fn` :t:`trait`, the :s
 
 .. _fls_3i4ou0dq64ny:
 
-Indirection Types
+Pointer Types
 -----------------
 
 .. rubric:: Legality Rules
 
 :dp:`fls_3qI8FXMsyk0f`
-A :t:`pointer type` is either a :t:`raw pointer type` or a :t:`reference type`.
+A :t:`pointer type` is a :t:`type` whose :t:`[value]s` refer to memory locations.
+
+:dp:`fls_f3TcmFrVoNis`
+A :t:`pointer` is a :t:`value` of a :t:`pointer type`.
+
+:dp:`fls_8RBNIR0E6pnI`
+A :t:`pointer` is :t:`dangling` if it is either :c:`null` or not all of the bytes at the referred memory location are part of the same allocation.
 
 .. _fls_xztr1kebz8bo:
 
@@ -973,8 +979,7 @@ Function Pointer Types
 .. rubric:: Legality Rules
 
 :dp:`fls_v2wrytr3t04h`
-A :t:`function pointer type` is an :t:`indirection type` that refers to a
-:t:`function`.
+A :t:`function pointer type` is a :t:`pointer type` that refers to a :t:`function`.
 
 :dp:`fls_5dd7icjcl3nt`
 An :t:`unsafe function pointer type` is a function pointer type subject to
@@ -1023,7 +1028,7 @@ Raw Pointer Types
 .. rubric:: Legality Rules
 
 :dp:`fls_rpbhr0xukbx9`
-A :t:`raw pointer type` is an :t:`indirection type` without validity guarantees.
+A :t:`raw pointer type` is a :t:`pointer type` without validity guarantees.
 
 :dp:`fls_bYWfGDAQcWfA`
 A :t:`mutable raw pointer type` is a :t:`raw pointer type` subject to
@@ -1064,7 +1069,7 @@ Reference Types
 .. rubric:: Legality Rules
 
 :dp:`fls_twhq24s8kchh`
-A :t:`reference type` is an :t:`indirection type` with :t:`ownership`.
+A :t:`reference type` is a :t:`pointer type` with :t:`ownership`.
 
 :dp:`fls_w4NbA7WhZfR2`
 A :t:`shared reference type` is a :t:`reference type` not subject to
@@ -1405,11 +1410,17 @@ Type Layout
 :dp:`fls_kdbq02iguzgl`
 All :t:`[value]s` have an :t:`alignment` and a :t:`size`.
 
+:dp:`fls_Im7miUSS87xs`
+A :t:`fixed sized type` is a :t:`type` that implements the :std:`core::marker::Sized` :t:`trait`.
+
+:dp:`fls_aQgOFrzAhdsC`
+A :t:`thin pointer type` is a :t:`pointer type` that refers to a :t:`fixed sized type`.
+
 :dp:`fls_26Xgem831Nqg`
-A :dt:`dynamically sized type` is a :t:`type` that does not implement the :std:`core::marker::Sized` :t:`trait`.
+A :t:`dynamically sized type` is a :t:`type` that does not implement the :std:`core::marker::Sized` :t:`trait`.
 
 :dp:`fls_ozYgHEHFTT5c`
-A :dt:`fat pointer type` is an :t:`indirection type` whose contained :t:`type specification` is a :t:`dynamically sized type`.
+A :t:`fat pointer type` is a :t:`pointer type` whose contained :t:`type specification` is a :t:`dynamically sized type`.
 
 :dp:`fls_muxfn9soi47l`
 The :t:`alignment` of a :t:`value` specifies which addresses are valid for

--- a/src/types-and-traits.rst
+++ b/src/types-and-traits.rst
@@ -120,16 +120,16 @@ Type Classification
     :t:`[Function item type]s`
 
 * :dp:`fls_jrohsv7hx7yw`
-  :t:`[Indirection type]s`
-
-  * :dp:`fls_1kg1mknf4yx7`
-    :t:`[Function pointer type]s`
+  :t:`[Pointer type]s`
 
   * :dp:`fls_bw8zutjcteki`
     :t:`[Raw pointer type]s`
 
   * :dp:`fls_nqezuc9u6wpn`
     :t:`[Reference type]s`
+
+* :dp:`fls_1kg1mknf4yx7`
+  :t:`[Function pointer type]s`
 
 * :dp:`fls_lh52q6f6snfh`
   :t:`[Trait type]s`
@@ -936,18 +936,90 @@ A :t:`function item type` implements the :std:`core::ops::Fn` :t:`trait`, the :s
 
 .. _fls_3i4ou0dq64ny:
 
-Indirection Types
------------------
+Pointer Types
+-------------
 
 .. rubric:: Legality Rules
 
 :dp:`fls_3qI8FXMsyk0f`
-A :t:`pointer type` is either a :t:`raw pointer type` or a :t:`reference type`.
+A :t:`pointer type` is a :t:`type` whose :t:`[value]s` refer to memory locations.
+
+.. _fls_ppd1xwve3tr7:
+
+Raw Pointer Types
+~~~~~~~~~~~~~~~~~
+
+.. rubric:: Syntax
+
+.. syntax::
+
+   RawPointerTypeSpecification ::=
+       $$*$$ ($$const$$ | $$mut$$) TypeSpecificationWithoutBounds
+
+.. rubric:: Legality Rules
+
+:dp:`fls_rpbhr0xukbx9`
+A :t:`raw pointer type` is a :t:`pointer type` without safety and liveness guarantees.
+
+:dp:`fls_8uWfFAsZeRCs`
+An :t:`immutable raw pointer type` is a :t:`raw pointer type` subject to :t:`keyword` ``const``.
+
+:dp:`fls_bYWfGDAQcWfA`
+A :t:`mutable raw pointer type` is a :t:`raw pointer type` subject to :t:`keyword` ``mut``.
+
+.. rubric:: Examples
+
+.. code-block:: rust
+
+   *const i128
+   *mut bool
+
+.. _fls_142vncdktbin:
+
+Reference Types
+~~~~~~~~~~~~~~~
+
+.. rubric:: Syntax
+
+.. syntax::
+
+   ReferenceTypeSpecification ::=
+       $$&$$ LifetimeIndication? $$mut$$? TypeSpecificationWithoutBounds
+
+.. rubric:: Legality Rules
+
+:dp:`fls_twhq24s8kchh`
+A :t:`reference type` is a :t:`pointer type` with :t:`ownership`.
+
+:dp:`fls_w4NbA7WhZfR2`
+A :t:`shared reference type` is a :t:`reference type` not subject to :t:`keyword` ``mut``.
+
+:dp:`fls_ie0avzljmxfm`
+A :t:`shared reference type` prevents the direct mutation of a referenced :t:`value`.
+
+:dp:`fls_15zdiqsm1q3p`
+A :t:`shared reference type` implements the :std:`core::marker::Copy` :t:`trait`.
+
+:dp:`fls_GUZuiST7ucib`
+A :t:`mutable reference type` is a :t:`reference type` subject to :t:`keyword` ``mut``.
+
+:dp:`fls_vaas9kns4zo6`
+A :t:`mutable reference type` allows the direct mutation of a referenced :t:`value`.
+
+:dp:`fls_n6ffcms5pr0r`
+A :t:`mutable reference type` does not implement the :std:`copy::marker::Copy` :t:`trait`.
+
+.. rubric:: Examples
+
+.. code-block:: rust
+
+   &i16
+   &'a mut f32
 
 .. _fls_xztr1kebz8bo:
 
 Function Pointer Types
-~~~~~~~~~~~~~~~~~~~~~~
+----------------------
 
 .. rubric:: Syntax
 
@@ -973,16 +1045,13 @@ Function Pointer Types
 .. rubric:: Legality Rules
 
 :dp:`fls_v2wrytr3t04h`
-A :t:`function pointer type` is an :t:`indirection type` that refers to a
-:t:`function`.
+A :t:`function pointer type` is a :t:`type` that refers to a :t:`function`.
 
 :dp:`fls_5dd7icjcl3nt`
-An :t:`unsafe function pointer type` is a function pointer type subject to
-:t:`keyword` ``unsafe``.
+An :t:`unsafe function pointer type` is a function pointer type subject to :t:`keyword` ``unsafe``.
 
 :dp:`fls_B0SMXRqQMS1E`
-A :t:`variadic part` indicates the presence of :t:`C`-like optional
-parameters.
+A :t:`variadic part` indicates the presence of :t:`C`-like optional parameters.
 
 :dp:`fls_hbn1l42xmr3h`
 A :t:`variadic part` can only be used in a :t:`variadic function`.
@@ -999,112 +1068,13 @@ The :t:`return type` of a :t:`function pointer type` is determined as follows:
 .. rubric:: Undefined Behavior
 
 :dp:`fls_52thmi9hnoks`
-It is a :t:`validity invariant` for a :t:`value` of a :t:`function pointer type`
-to be not :c:`null`.
+It is a :t:`validity invariant` for a :t:`value` of a :t:`function pointer type` to be not :c:`null`.
 
 .. rubric:: Examples
 
 .. code-block:: rust
 
    unsafe extern "C" fn (value: i32, ...) -> f64
-
-.. _fls_ppd1xwve3tr7:
-
-Raw Pointer Types
-~~~~~~~~~~~~~~~~~
-
-.. rubric:: Syntax
-
-.. syntax::
-
-   RawPointerTypeSpecification ::=
-       $$*$$ ($$const$$ | $$mut$$) TypeSpecificationWithoutBounds
-
-.. rubric:: Legality Rules
-
-:dp:`fls_rpbhr0xukbx9`
-A :t:`raw pointer type` is an :t:`indirection type` without validity guarantees.
-
-:dp:`fls_bYWfGDAQcWfA`
-A :t:`mutable raw pointer type` is a :t:`raw pointer type` subject to
-:t:`keyword` ``mut``.
-
-:dp:`fls_8uWfFAsZeRCs`
-An :t:`immutable raw pointer type` is a :t:`raw pointer type` subject to
-:t:`keyword` ``const``.
-
-:dp:`fls_c2Guy3fPYaUV`
-A :t:`raw pointer` is a :t:`value` of a :t:`raw pointer type`.
-
-:dp:`fls_hrum767l6dte`
-Comparing two :t:`[raw pointer]s` compares the addresses of the :t:`[raw pointer]s`.
-
-:dp:`fls_k6ues2936pjq`
-Comparing a :t:`raw pointer` to a :t:`value` of a :t:`dynamically sized type` compares the data being pointed to.
-
-.. rubric:: Examples
-
-.. code-block:: rust
-
-   *const i128
-   *mut bool
-
-.. _fls_142vncdktbin:
-
-Reference Types
-~~~~~~~~~~~~~~~
-
-.. rubric:: Syntax
-
-.. syntax::
-
-   ReferenceTypeSpecification ::=
-       $$&$$ LifetimeIndication? $$mut$$? TypeSpecificationWithoutBounds
-
-.. rubric:: Legality Rules
-
-:dp:`fls_twhq24s8kchh`
-A :t:`reference type` is an :t:`indirection type` with :t:`ownership`.
-
-:dp:`fls_w4NbA7WhZfR2`
-A :t:`shared reference type` is a :t:`reference type` not subject to
-:t:`keyword` ``mut``.
-
-:dp:`fls_ie0avzljmxfm`
-A :t:`shared reference type` prevents the direct mutation of a referenced
-:t:`value`.
-
-:dp:`fls_15zdiqsm1q3p`
-A :t:`shared reference type` implements the :std:`core::marker::Copy`
-:t:`trait`. Copying a :t:`shared reference` performs a shallow copy.
-
-:dp:`fls_csdjfwczlzfd`
-Releasing a :t:`shared reference` has no effect on the :t:`value` it refers to.
-
-:dp:`fls_GUZuiST7ucib`
-A :t:`mutable reference type` is a :t:`reference type` subject to :t:`keyword`
-``mut``.
-
-:dp:`fls_vaas9kns4zo6`
-A :t:`mutable reference type` allows the direct mutation of a referenced
-:t:`value`.
-
-:dp:`fls_n6ffcms5pr0r`
-A :t:`mutable reference type` does not implement the :std:`copy::marker::Copy`
-:t:`trait`.
-
-.. rubric:: Undefined Behavior
-
-:dp:`fls_ezh8aq6fmdvz`
-It is :t:`validity invariant` for a :t:`value` of a :t:`reference type` to be
-not :c:`null`.
-
-.. rubric:: Examples
-
-.. code-block:: rust
-
-   &i16
-   &'a mut f32
 
 .. _fls_1ompd93w7c9f:
 
@@ -1405,11 +1375,17 @@ Type Layout
 :dp:`fls_kdbq02iguzgl`
 All :t:`[value]s` have an :t:`alignment` and a :t:`size`.
 
+:dp:`fls_Im7miUSS87xs`
+A :t:`fixed sized type` is a :t:`type` that implements the :std:`core::marker::Sized` :t:`trait`.
+
+:dp:`fls_aQgOFrzAhdsC`
+A :t:`thin pointer type` is a :t:`pointer type` that refers to a :t:`fixed sized type`.
+
 :dp:`fls_26Xgem831Nqg`
-A :dt:`dynamically sized type` is a :t:`type` that does not implement the :std:`core::marker::Sized` :t:`trait`.
+A :t:`dynamically sized type` is a :t:`type` that does not implement the :std:`core::marker::Sized` :t:`trait`.
 
 :dp:`fls_ozYgHEHFTT5c`
-A :dt:`fat pointer type` is an :t:`indirection type` whose contained :t:`type specification` is a :t:`dynamically sized type`.
+A :t:`fat pointer type` is a :t:`pointer type` whose contained :t:`type specification` is a :t:`dynamically sized type`.
 
 :dp:`fls_muxfn9soi47l`
 The :t:`alignment` of a :t:`value` specifies which addresses are valid for
@@ -1483,16 +1459,13 @@ the :t:`size` is zero and the :t:`alignment` is one.
 For a :t:`closure type`, the :t:`layout` is tool-defined.
 
 :dp:`fls_18ke90udyp67`
-For a :t:`thin pointer`, the :t:`size` and :t:`alignment` are those of :t:`type`
-:c:`usize`.
+For a :t:`thin pointer`, the :t:`size` and :t:`alignment` are those of :t:`type` :c:`usize`.
 
 :dp:`fls_nrqG8i3fmpm4`
-For a :t:`function pointer type`, the :t:`size` and :t:`alignment` are those of
-a :t:`thin pointer`.
+For a :t:`function pointer type`, the :t:`size` and :t:`alignment` are those of a :t:`thin pointer`.
 
 :dp:`fls_e5hivr6m5s3h`
-For a :t:`fat pointer type`, the :t:`size` and :t:`alignment` are tool-defined, but
-are at least those of a :t:`thin pointer`.
+For a :t:`fat pointer type`, the :t:`size` and :t:`alignment` are tool-defined, but are at least those of a :t:`thin pointer`.
 For a :t:`fat pointer type` whose contained :t:`type` is that of a :t:`slice` or :t:`trait object type` the :t:`size` is that of two times the size of :t:`type` :c:`usize` and the :t:`alignment` is that of :t:`type` :c:`usize`.
 
 :dp:`fls_hlbsjggfxnt2`

--- a/src/values.rst
+++ b/src/values.rst
@@ -62,39 +62,6 @@ It is undefined behavior to create an :t:`allocated object` with :t:`memory
 size` ``size`` where ``size`` is greater than the architectures maximum
 :c:`isize` value.
 
-.. _fls_Dqk4eIvxHloY:
-
-Provenance
-----------
-
-.. rubric:: Legality Rules
-
-:dp:`fls_jriT46yWgIR0`
-A :t:`pointer` is a :t:`value` of a :t:`pointer type`.
-
-:dp:`fls_VWUlxTy0QF9d`
-An :t:`original pointer` is a :t:`pointer` created via allocation.
-
-:dp:`fls_kaPNJ7iIHPro`
-A :t:`derived pointer` is a :t:`pointer` obtained by :t:`borrowing`, copying a :t:`pointer`, reading a stored :t:`pointer`, performing :t:`pointer` arithmetic, or :t:`casting` a :t:`pointer`.
-
-:dp:`fls_5MkKtNL9oCsL`
-:t:`Provenance` is an optional property of :t:`[pointer]s` that restricts the memory locations the :t:`pointer` may access, the timespan during which the accesses may occur, and whether the accesses may read from or write to said memory locations.
-
-:dp:`fls_1NJhTBN1D2qv`
-An :t:`original pointer` carries :t:`provenance` over all or part of the :t:`allocated object` it was created from.
-
-:dp:`fls_wnJmQYT7iKQf`
-A :t:`derived pointer` inherits the :t:`provenance` of the :t:`pointer` it was created from, if any.
-
-:dp:`fls_ffh8mAkebORJ`
-A :t:`well-formed pointer` is a :t:`pointer` where either no byte of the :t:`pointer` carries :t:`provenance`, or every byte of the :t:`pointer` is the corresponding byte of a single :t:`pointer` with :t:`provenance`.
-
-.. rubric:: Undefined Behavior
-
-:dp:`fls_c3DaCLQEBpYQ`
-It is undefined behavior to access memory through a :t:`pointer` that does not have :t:`provenance` permitting the access.
-
 .. _fls_ixjc5jaamx84:
 
 Constants
@@ -157,6 +124,95 @@ the :t:`constant`.
 .. code-block:: rust
 
    const ZERO: u32 = 0;
+
+.. _fls_xOuhiItK1hK0:
+
+Pointers
+--------
+
+.. rubric:: Legality Rules
+
+:dp:`fls_f3TcmFrVoNis`
+A :t:`pointer` is a :t:`value` of a :t:`pointer type`.
+
+:dp:`fls_8RBNIR0E6pnI`
+A :t:`pointer` is :t:`dangling` if it is either :c:`null` or not all of the bytes at the referred memory location are part of the same allocation.
+
+:dp:`fls_jnCncQ9PpqWf`
+A :t:`thin pointer` is a :t:`value` of a :t:`thin pointer type`.
+
+:dp:`fls_qpARFqqnKGMn`
+A :t:`fat pointer` is a :t:`value` of a :t:`fat pointer type`.
+
+:dp:`fls_VWUlxTy0QF9d`
+An :t:`original pointer` is a :t:`pointer` created via allocation.
+
+:dp:`fls_kaPNJ7iIHPro`
+A :t:`derived pointer` is a :t:`pointer` obtained by :t:`borrowing`, copying a :t:`pointer`, reading a stored :t:`pointer`, performing :t:`pointer` arithmetic, or :t:`casting` a :t:`pointer`.
+
+.. _fls_qPWQnNXH52R3:
+
+Raw Pointers
+~~~~~~~~~~~~
+
+.. rubric:: Legality Rules
+
+:dp:`fls_c2Guy3fPYaUV`
+A :t:`raw pointer` is a :t:`value` of a :t:`raw pointer type`.
+
+:dp:`fls_hrum767l6dte`
+Comparing two :t:`[raw pointer]s` compares the addresses of the :t:`[raw pointer]s`.
+
+:dp:`fls_k6ues2936pjq`
+Comparing a :t:`raw pointer` to a :t:`value` of a :t:`dynamically sized type` compares the data being pointed to.
+
+.. _fls_phgP8YIwpXpi:
+
+References
+~~~~~~~~~~
+
+.. rubric:: Legality Rules
+
+:dp:`fls_fHDXn6CafgU7`
+A :t:`shared reference` is a :t:`value` of a :t:`shared reference type`.
+
+:dp:`fls_ftE05Blr5Esv`
+Copying a :t:`shared reference` performs a shallow copy.
+
+:dp:`fls_csdjfwczlzfd`
+Releasing a :t:`shared reference` has no effect on the :t:`value` it refers to.
+
+:dp:`fls_3szBrTEI2Rzo`
+A :t:`mutable reference` is a :t:`value` of a :t:`mutable reference type`.
+
+.. rubric:: Undefined Behavior
+
+:dp:`fls_ezh8aq6fmdvz`
+It is :t:`validity invariant` for a :t:`value` of a :t:`reference type` to be not :c:`null`.
+
+.. _fls_Dqk4eIvxHloY:
+
+Provenance
+~~~~~~~~~~
+
+.. rubric:: Legality Rules
+
+:dp:`fls_5MkKtNL9oCsL`
+:t:`Provenance` is an optional property of :t:`[pointer]s` that restricts the memory locations the :t:`pointer` may access, the timespan during which the accesses may occur, and whether the accesses may read from or write to said memory locations.
+
+:dp:`fls_1NJhTBN1D2qv`
+An :t:`original pointer` carries :t:`provenance` over all or part of the :t:`allocated object` it was created from.
+
+:dp:`fls_wnJmQYT7iKQf`
+A :t:`derived pointer` inherits the :t:`provenance` of the :t:`pointer` it was created from, if any.
+
+:dp:`fls_ffh8mAkebORJ`
+A :t:`well-formed pointer` is a :t:`pointer` where either no byte of the :t:`pointer` carries :t:`provenance`, or every byte of the :t:`pointer` is the corresponding byte of a single :t:`pointer` with :t:`provenance`.
+
+.. rubric:: Undefined Behavior
+
+:dp:`fls_c3DaCLQEBpYQ`
+It is undefined behavior to access memory through a :t:`pointer` that does not have :t:`provenance` permitting the access.
 
 .. _fls_xdvdl2ssnhlo:
 

--- a/src/values.rst
+++ b/src/values.rst
@@ -132,7 +132,7 @@ Pointers
 
 .. rubric:: Legality Rules
 
-:dp:`fls_f3TcmFrVoNis`
+:dp:`fls_jriT46yWgIR0`
 A :t:`pointer` is a :t:`value` of a :t:`pointer type`.
 
 :dp:`fls_8RBNIR0E6pnI`


### PR DESCRIPTION
This PR removes the term "indirection" and its derivatives from the FLS as the Rust Project does not use this term. The preferred alternative is "pointer", "pointer type", etc.

Closes: https://github.com/rust-lang/fls/issues/710