### PR TITLE
Fix leading qualifiers in use-import prefixes

### DIFF
--- a/src/changelog.rst
+++ b/src/changelog.rst
@@ -36,6 +36,7 @@ FLS maintenance
   - :p:`fls_gAWsqibl4GLq`
   - :p:`fls_irdKqoYzBM0M`
   - :p:`fls_JHU0ersYB6eL`
+  - :p:`fls_iNUBX5fJAI1N`
   - :p:`fls_aam34hsRmKU2`
 
   New paragraphs:

--- a/src/changelog.rst
+++ b/src/changelog.rst
@@ -238,6 +238,27 @@ Language changes in Rust 1.95.0
 FLS maintenance
 ---------------
 
+- Fix the construction of :t:`[import path prefix]es` to preserve leading :t:`[namespace qualifier]s`.
+
+  Changed syntax: :s:`CommonPathPrefix`
+
+  Changed paragraphs:
+
+  - :p:`fls_sxo1jb25pl8a`
+  - :p:`fls_WAA4WmohGu6T`
+  - :p:`fls_IPYvldMqduf4`
+  - :p:`fls_MOXId37fcNPY`
+  - :p:`fls_2UyFcB6Our1v`
+  - :p:`fls_gAWsqibl4GLq`
+  - :p:`fls_irdKqoYzBM0M`
+  - :p:`fls_aam34hsRmKU2`
+
+  New paragraphs:
+
+  - :p:`fls_lfsIPXV0OTI5`
+  - :p:`fls_BMtRtjJ7gBKT`
+  - :p:`fls_UZHHtqJ0ekju`
+
 - Replace the term "simple path prefix" with "common path prefix", to improve clarity.
 
 - Changed paragraphs:

--- a/src/changelog.rst
+++ b/src/changelog.rst
@@ -22,7 +22,7 @@ with the change that has been applied due to it.
 FLS maintenance
 ---------------
 
-- Fix the construction of :t:`[import path prefix]es` to preserve leading :t:`[namespace qualifier]s`.
+- Fix the construction of :t:`[import path prefix]es` to preserve leading :t:`[namespace qualifier]s`, and permit :t:`[global path]s` to refer to :t:`shadowed` :t:`[name]s` from the :t:`external prelude`.
 
   Changed paragraphs:
 
@@ -35,6 +35,8 @@ FLS maintenance
   - :p:`fls_JHU0ersYB6eL`
   - :p:`fls_iNUBX5fJAI1N`
   - :p:`fls_aam34hsRmKU2`
+  - :p:`fls_ob0riinmitkl`
+  - :p:`fls_bATFGtxjKq0B`
 
   New paragraphs:
 

--- a/src/changelog.rst
+++ b/src/changelog.rst
@@ -24,26 +24,23 @@ FLS maintenance
 
 - Fix the construction of :t:`[import path prefix]es` to preserve leading :t:`[namespace qualifier]s`.
 
-  Changed syntax: :s:`CommonPathPrefix`
-
   Changed paragraphs:
 
-  - :p:`fls_sxo1jb25pl8a`
   - :p:`fls_WAA4WmohGu6T`
+  - :p:`fls_gAWsqibl4GLq`
+  - :p:`fls_irdKqoYzBM0M`
   - :p:`fls_IPYvldMqduf4`
   - :p:`fls_MOXId37fcNPY`
   - :p:`fls_2UyFcB6Our1v`
-  - :p:`fls_gAWsqibl4GLq`
-  - :p:`fls_irdKqoYzBM0M`
   - :p:`fls_JHU0ersYB6eL`
   - :p:`fls_iNUBX5fJAI1N`
   - :p:`fls_aam34hsRmKU2`
 
   New paragraphs:
 
-  - :p:`fls_lfsIPXV0OTI5`
   - :p:`fls_BMtRtjJ7gBKT`
   - :p:`fls_UZHHtqJ0ekju`
+
 - Remove the term "indirection", and associated derivatives
 
   Changed glossary entries:

--- a/src/changelog.rst
+++ b/src/changelog.rst
@@ -19,6 +19,31 @@ with the change that has been applied due to it.
    just the language changes that had an impact to the FLS. See the `release
    notes`_ for a full list of changes.
 
+FLS maintenance
+---------------
+
+- Fix the construction of :t:`[import path prefix]es` to preserve leading :t:`[namespace qualifier]s`.
+
+  Changed syntax: :s:`CommonPathPrefix`
+
+  Changed paragraphs:
+
+  - :p:`fls_sxo1jb25pl8a`
+  - :p:`fls_WAA4WmohGu6T`
+  - :p:`fls_IPYvldMqduf4`
+  - :p:`fls_MOXId37fcNPY`
+  - :p:`fls_2UyFcB6Our1v`
+  - :p:`fls_gAWsqibl4GLq`
+  - :p:`fls_irdKqoYzBM0M`
+  - :p:`fls_JHU0ersYB6eL`
+  - :p:`fls_aam34hsRmKU2`
+
+  New paragraphs:
+
+  - :p:`fls_lfsIPXV0OTI5`
+  - :p:`fls_BMtRtjJ7gBKT`
+  - :p:`fls_UZHHtqJ0ekju`
+
 Language changes in Rust 1.96.0
 -------------------------------
 
@@ -237,27 +262,6 @@ Language changes in Rust 1.95.0
 
 FLS maintenance
 ---------------
-
-- Fix the construction of :t:`[import path prefix]es` to preserve leading :t:`[namespace qualifier]s`.
-
-  Changed syntax: :s:`CommonPathPrefix`
-
-  Changed paragraphs:
-
-  - :p:`fls_sxo1jb25pl8a`
-  - :p:`fls_WAA4WmohGu6T`
-  - :p:`fls_IPYvldMqduf4`
-  - :p:`fls_MOXId37fcNPY`
-  - :p:`fls_2UyFcB6Our1v`
-  - :p:`fls_gAWsqibl4GLq`
-  - :p:`fls_irdKqoYzBM0M`
-  - :p:`fls_aam34hsRmKU2`
-
-  New paragraphs:
-
-  - :p:`fls_lfsIPXV0OTI5`
-  - :p:`fls_BMtRtjJ7gBKT`
-  - :p:`fls_UZHHtqJ0ekju`
 
 - Replace the term "simple path prefix" with "common path prefix", to improve clarity.
 

--- a/src/entities-and-resolution.rst
+++ b/src/entities-and-resolution.rst
@@ -1103,8 +1103,7 @@ A :t:`nesting import` is a :t:`use import` that provides a common
 :t:`common path prefix` for its nested :t:`[use import]s`.
 
 :dp:`fls_iNUBX5fJAI1N`
-A :t:`glob import` outside of a :t:`nesting import` without a :t:`common path
-prefix` is rejected, but may still be consumed by :t:`[macro]s`.
+A :t:`glob import` whose :t:`import path prefix` is empty or consists only of :t:`namespace qualifier` ``::`` is rejected, but may still be consumed by :t:`[macro]s`.
 
 :dp:`fls_wB3fVglLOqbZ`
 It is a static error if two :t:`[glob import]s` import the same :t:`name` in the
@@ -1125,7 +1124,7 @@ A :t:`use import` with a single :t:`path segment` expressed as either :t:`keywor
 When a :t:`path segment` expressed as :t:`keyword` ``super`` is used to import a parent :t:`module`, the imported :t:`entity` shall be subject to a :t:`renaming`.
 
 :dp:`fls_aam34hsRmKU2`
-The :t:`import path prefix` of a :t:`glob import` shall neither be empty nor consist only of :t:`namespace qualifier` ``::``. An :t:`import path prefix` that selects the :t:`entity` of a :t:`simple import` shall not consist only of :t:`namespace qualifier` ``::``.
+An :t:`import path prefix` that selects the :t:`entity` of a :t:`simple import` shall not consist only of :t:`namespace qualifier` ``::``.
 
 :dp:`fls_LV94x3HlpBWk`
 A :t:`simple import` shall not refer to :t:`[enum variant]s` through a :t:`type alias`.

--- a/src/entities-and-resolution.rst
+++ b/src/entities-and-resolution.rst
@@ -1065,7 +1065,10 @@ exported by the :t:`module` or :t:`enum` its :t:`import path prefix` resolves to
 into :t:`scope`.
 
 :dp:`fls_BMtRtjJ7gBKT`
-Each :t:`namespace qualifier` of an :t:`import path prefix` shall either be the first element of the :t:`import path prefix` or appear between two :t:`[path segment]s`.
+A :t:`simple import`, :t:`glob import`, or :t:`nesting import` expressed with a
+leading :t:`namespace qualifier` ``::`` shall not be nested, directly or
+indirectly, within any :t:`nesting import` whose :s:`CommonPathPrefix` is
+present.
 
 :dp:`fls_UZHHtqJ0ekju`
 An empty :t:`import path prefix` that selects the :t:`entity` of a :t:`simple import` resolves to the current :t:`module`.

--- a/src/entities-and-resolution.rst
+++ b/src/entities-and-resolution.rst
@@ -1166,10 +1166,7 @@ Shadowing
 .. rubric:: Legality Rules
 
 :dp:`fls_ob0riinmitkl`
-:t:`Shadowing` is a property of :t:`[name]s`. A :t:`name` is said to be
-:t:`shadowed` when another :t:`name` with the same characters is introduced
-in the same :t:`scope` within the same :t:`namespace`, effectively hiding it.
-A :t:`name` cannot be referred to by any means once it is :t:`shadowed`.
+:t:`Shadowing` is a property of :t:`[name]s`. A :t:`name` is said to be :t:`shadowed` when another :t:`name` with the same characters is introduced in the same :t:`scope` within the same :t:`namespace`, effectively hiding it. A :t:`name` cannot be referred to once it is :t:`shadowed`, except that a :t:`name` introduced by the :t:`external prelude` may be used as the leftmost :t:`path segment` of a :t:`global path`.
 
 :dp:`fls_fslg89a70e3n`
 No :t:`name` shall be :t:`shadowed` except for
@@ -1611,8 +1608,7 @@ The resolution of the rightmost :t:`path segment` is determined based on the
 :t:`candidate selected entity` is restricted by the :t:`namespace context`.
 
 :dp:`fls_bATFGtxjKq0B`
-It is a static error if the leftmost :t:`path segment` is an :t:`identifier`
-introduced by the :t:`external prelude` that is also :t:`shadowed <shadowing>`.
+It is a static error if the leftmost :t:`path segment` of a :t:`path` that is not a :t:`global path` is an :t:`identifier` introduced by the :t:`external prelude` that is also :t:`shadowed <shadowing>`.
 
 .. _fls_bbso3c45kr9z:
 

--- a/src/entities-and-resolution.rst
+++ b/src/entities-and-resolution.rst
@@ -1005,7 +1005,8 @@ Use Imports
        SimplePath Renaming?
 
    CommonPathPrefix ::=
-       SimplePath? $$::$$
+       SimplePath $$::$$
+     | $$::$$
 
    UseImportContentList ::=
        UseImportContent ($$,$$ UseImportContent)* $$,$$?
@@ -1018,35 +1019,28 @@ A :t:`use import` brings :t:`entities <entity>` :t:`in scope` within the
 :t:`use import` resides.
 
 :dp:`fls_sxo1jb25pl8a`
-A :dt:`common path prefix` is the leading :t:`simple path` of a :t:`glob import`
-or a :t:`nesting import`.
+A :dt:`common path prefix` is the :t:`simple path` of a :s:`CommonPathPrefix` when one is present, and otherwise consists only of :t:`namespace qualifier` ``::``.
 
 :dp:`fls_WAA4WmohGu6T`
-An :dt:`import path prefix` is the fully constructed :t:`path` prefix of a
-:t:`use import`. An :t:`import path prefix` for a given
-:t:`simple import` or :t:`glob import` is constructed as follows:
+An :dt:`import path prefix` is the fully constructed sequence of :t:`[path segment]s` and :t:`[namespace qualifier]s` that precedes the selected :t:`entity` of a :t:`simple import` or the character asterisk ``*`` of a :t:`glob import`. The :t:`import path prefix` for a given :t:`simple import` or :t:`glob import` is constructed as follows:
 
 #. :dp:`fls_IPYvldMqduf4`
-   Start the :t:`import path prefix` as follows:
+   Make the given :t:`use import` the current :t:`use import`, and start the :t:`import path prefix` as follows:
 
    * :dp:`fls_MOXId37fcNPY`
-     If the :t:`use import` is a :t:`simple import` then start with the
-     :t:`[path segment]s` of the :t:`simple import`'s :t:`simple path`
-     :t:`path prefix`.
+     If the :t:`use import` is a :t:`simple import`, then start with the :t:`simple import`'s :t:`simple path` :t:`path prefix`, retaining any leading :t:`namespace qualifier` of the :t:`simple path`.
 
    * :dp:`fls_2UyFcB6Our1v`
-     If the :t:`use import` is a :t:`glob import` then start with the
-     :t:`[path segment]s` of the :t:`glob import`'s :t:`common path prefix`.
-
-   * :dp:`fls_irdKqoYzBM0M`
-     If the :t:`use import` is a :t:`nesting import` then start with the
-     :t:`[path segment]s` of the :t:`nesting import`'s :t:`common path prefix`.
+     If the :t:`use import` is a :t:`glob import`, then start with the :t:`glob import`'s :t:`common path prefix`, or an empty sequence if the :t:`glob import` lacks a :t:`common path prefix`.
 
 #. :dp:`fls_gAWsqibl4GLq`
-   Then if the current :t:`use import` is the child of a :t:`nesting import`,
-   prepend the :t:`nesting import`'s :t:`common path prefix` to the
-   :t:`import path prefix`. Repeat this step with the :t:`nesting import` as
-   the current :t:`use import`.
+   While the current :t:`use import` is the child of a :t:`nesting import`, repeat the following steps:
+
+   * :dp:`fls_irdKqoYzBM0M`
+     If the :t:`nesting import` has a :t:`common path prefix`, prepend the :t:`common path prefix` to the :t:`import path prefix`. If the :t:`common path prefix` contains a :t:`path segment` and the :t:`import path prefix` was not empty, place a :t:`namespace qualifier` ``::`` between them.
+
+   * :dp:`fls_lfsIPXV0OTI5`
+     Make the :t:`nesting import` the current :t:`use import`.
 
 :dp:`fls_2bkcn83smy2y`
 A :dt:`simple import` is a :t:`use import` that brings into :t:`scope` an :t:`entity` selected by its :t:`simple import path`, or by its :t:`import path prefix` when its :t:`simple path` ends in :t:`keyword` ``self`` and the :t:`simple path` appears in a :t:`nesting import`.
@@ -1055,6 +1049,12 @@ A :dt:`simple import` is a :t:`use import` that brings into :t:`scope` an :t:`en
 A :t:`glob import` is a :t:`use import` that brings all :t:`entities <entity>`
 exported by the :t:`module` or :t:`enum` its :t:`import path prefix` resolves to
 into :t:`scope`.
+
+:dp:`fls_BMtRtjJ7gBKT`
+Each :t:`namespace qualifier` of an :t:`import path prefix` shall either be the first element of the :t:`import path prefix` or appear between two :t:`[path segment]s`.
+
+:dp:`fls_UZHHtqJ0ekju`
+An empty :t:`import path prefix` resolves to the current :t:`module`.
 
 :dp:`fls_JHU0ersYB6eL`
 An :t:`import path prefix` shall resolve to a :t:`module` or :t:`enum`.
@@ -1125,7 +1125,7 @@ A :t:`use import` with a single :t:`path segment` expressed as either :t:`keywor
 When a :t:`path segment` expressed as :t:`keyword` ``super`` is used to import a parent :t:`module`, the imported :t:`entity` shall be subject to a :t:`renaming`.
 
 :dp:`fls_aam34hsRmKU2`
-A :t:`simple import` whose :t:`import path prefix` consists only of :t:`namespace qualifier` ``::`` and whose :t:`simple path` consists of a single :t:`path segment` expressed as :t:`keyword` ``self`` shall not be used.
+An :t:`import path prefix` shall not consist only of :t:`namespace qualifier` ``::`` when it is the :t:`import path prefix` of a :t:`glob import` or selects the :t:`entity` of a :t:`simple import`.
 
 :dp:`fls_LV94x3HlpBWk`
 A :t:`simple import` shall not refer to :t:`[enum variant]s` through a :t:`type alias`.

--- a/src/entities-and-resolution.rst
+++ b/src/entities-and-resolution.rst
@@ -1025,16 +1025,16 @@ A :dt:`common path prefix` is the leading :t:`simple path` of a :t:`glob import`
 or a :t:`nesting import`.
 
 :dp:`fls_WAA4WmohGu6T`
-An :dt:`import path prefix` is a sequence of :t:`[path segment]s` and
-:t:`[namespace qualifier]s` associated with a :t:`simple import` or
-:t:`glob import`. The :t:`import path prefix` is formed by concatenating the
+An :dt:`import path prefix` is a sequence of :t:`[namespace qualifier]s` and
+:t:`[path segment]s` associated with a :t:`glob import` or
+:t:`simple import`. The :t:`import path prefix` is formed by concatenating the
 following sequences in order. When concatenation would place two
 :t:`[path segment]s` next to each other, :t:`namespace qualifier` ``::`` is
 placed between them.
 
 #. :dp:`fls_gAWsqibl4GLq`
-   For each :t:`nesting import` in which the :t:`simple import` or
-   :t:`glob import` is nested, from outermost to innermost:
+   For each :t:`nesting import` in which the :t:`glob import` or
+   :t:`simple import` is nested, from outermost to innermost:
 
    * :dp:`fls_irdKqoYzBM0M`
      The :t:`nesting import`'s :t:`common path prefix` if it has one,
@@ -1044,17 +1044,17 @@ placed between them.
 #. :dp:`fls_IPYvldMqduf4`
    A sequence determined by the kind of import:
 
-   * :dp:`fls_MOXId37fcNPY`
-     For a :t:`simple import`, the :t:`simple import`'s :t:`simple path` after
-     removing its last :t:`path segment` and, if another :t:`path segment`
-     precedes the last :t:`path segment`, the :t:`namespace qualifier` that
-     separates them.
-
    * :dp:`fls_2UyFcB6Our1v`
      For a :t:`glob import`, the :t:`glob import`'s :t:`common path prefix` if
      it has one, :t:`namespace qualifier` ``::`` if it lacks a
      :t:`common path prefix` and its :s:`CommonPathPrefix` is present, or an
      empty sequence otherwise.
+
+   * :dp:`fls_MOXId37fcNPY`
+     For a :t:`simple import`, the :t:`simple import`'s :t:`simple path` after
+     removing its last :t:`path segment` and, if another :t:`path segment`
+     precedes the last :t:`path segment`, the :t:`namespace qualifier` that
+     separates them.
 
 :dp:`fls_2bkcn83smy2y`
 A :dt:`simple import` is a :t:`use import` that brings into :t:`scope` an :t:`entity` selected by its :t:`simple import path`, or by its :t:`import path prefix` when its :t:`simple path` ends in :t:`keyword` ``self``.
@@ -1065,7 +1065,7 @@ exported by the :t:`module` or :t:`enum` its :t:`import path prefix` resolves to
 into :t:`scope`.
 
 :dp:`fls_BMtRtjJ7gBKT`
-A :t:`simple import`, :t:`glob import`, or :t:`nesting import` expressed with a
+A :t:`glob import`, :t:`nesting import`, or :t:`simple import` expressed with a
 leading :t:`namespace qualifier` ``::`` shall not be nested, directly or
 indirectly, within any :t:`nesting import` whose :s:`CommonPathPrefix` is
 present.
@@ -1074,7 +1074,7 @@ present.
 An empty :t:`import path prefix` that selects the :t:`entity` of a :t:`simple import` resolves to the current :t:`module`.
 
 :dp:`fls_JHU0ersYB6eL`
-An :t:`import path prefix` that contains a :t:`path segment` shall resolve to a :t:`module` or :t:`enum`.
+An :t:`import path prefix` that contains a :t:`path segment` shall resolve to an :t:`enum` or :t:`module`.
 
 :dp:`fls_jlNKxkuhsvX4`
 A :t:`glob import` brings :t:`[name]s` into :t:`scope` as follows:

--- a/src/entities-and-resolution.rst
+++ b/src/entities-and-resolution.rst
@@ -1025,36 +1025,22 @@ A :dt:`common path prefix` is the leading :t:`simple path` of a :t:`glob import`
 or a :t:`nesting import`.
 
 :dp:`fls_WAA4WmohGu6T`
-An :dt:`import path prefix` is a sequence of :t:`[namespace qualifier]s` and
-:t:`[path segment]s` associated with a :t:`glob import` or
-:t:`simple import`. The :t:`import path prefix` is formed by concatenating the
-following sequences in order. When concatenation would place two
-:t:`[path segment]s` next to each other, :t:`namespace qualifier` ``::`` is
-placed between them.
+An :dt:`import path prefix` is a sequence of :t:`[namespace qualifier]s` and :t:`[path segment]s` associated with a :t:`glob import` or :t:`simple import`. The :t:`import path prefix` is formed by concatenating the following sequences in order. When concatenation would place two :t:`[path segment]s` next to each other, :t:`namespace qualifier` ``::`` is placed between them.
 
 #. :dp:`fls_gAWsqibl4GLq`
-   For each :t:`nesting import` in which the :t:`glob import` or
-   :t:`simple import` is nested, from outermost to innermost:
+   For each :t:`nesting import` in which the :t:`glob import` or :t:`simple import` is nested, from outermost to innermost:
 
    * :dp:`fls_irdKqoYzBM0M`
-     The :t:`nesting import`'s :t:`common path prefix` if it has one,
-     :t:`namespace qualifier` ``::`` if it lacks a :t:`common path prefix`
-     and its :s:`CommonPathPrefix` is present, or an empty sequence otherwise.
+     The :t:`nesting import`'s :t:`common path prefix` if it has one, :t:`namespace qualifier` ``::`` if it lacks a :t:`common path prefix` and its :s:`CommonPathPrefix` is present, or an empty sequence otherwise.
 
 #. :dp:`fls_IPYvldMqduf4`
    A sequence determined by the kind of import:
 
    * :dp:`fls_2UyFcB6Our1v`
-     For a :t:`glob import`, the :t:`glob import`'s :t:`common path prefix` if
-     it has one, :t:`namespace qualifier` ``::`` if it lacks a
-     :t:`common path prefix` and its :s:`CommonPathPrefix` is present, or an
-     empty sequence otherwise.
+     For a :t:`glob import`, the :t:`glob import`'s :t:`common path prefix` if it has one, :t:`namespace qualifier` ``::`` if it lacks a :t:`common path prefix` and its :s:`CommonPathPrefix` is present, or an empty sequence otherwise.
 
    * :dp:`fls_MOXId37fcNPY`
-     For a :t:`simple import`, the :t:`simple import`'s :t:`simple path` after
-     removing its last :t:`path segment` and, if another :t:`path segment`
-     precedes the last :t:`path segment`, the :t:`namespace qualifier` that
-     separates them.
+     For a :t:`simple import`, the :t:`simple import`'s :t:`simple path` after removing its last :t:`path segment` and, if another :t:`path segment` precedes the last :t:`path segment`, the :t:`namespace qualifier` that separates them.
 
 :dp:`fls_2bkcn83smy2y`
 A :dt:`simple import` is a :t:`use import` that brings into :t:`scope` an :t:`entity` selected by its :t:`simple import path`, or by its :t:`import path prefix` when its :t:`simple path` ends in :t:`keyword` ``self``.
@@ -1065,10 +1051,7 @@ exported by the :t:`module` or :t:`enum` its :t:`import path prefix` resolves to
 into :t:`scope`.
 
 :dp:`fls_BMtRtjJ7gBKT`
-A :t:`glob import`, :t:`nesting import`, or :t:`simple import` expressed with a
-leading :t:`namespace qualifier` ``::`` shall not be nested, directly or
-indirectly, within any :t:`nesting import` whose :s:`CommonPathPrefix` is
-present.
+A :t:`glob import`, :t:`nesting import`, or :t:`simple import` expressed with a leading :t:`namespace qualifier` ``::`` shall not be nested, directly or indirectly, within any :t:`nesting import` whose :s:`CommonPathPrefix` is present.
 
 :dp:`fls_UZHHtqJ0ekju`
 An empty :t:`import path prefix` that selects the :t:`entity` of a :t:`simple import` resolves to the current :t:`module`.

--- a/src/entities-and-resolution.rst
+++ b/src/entities-and-resolution.rst
@@ -1008,8 +1008,7 @@ Use Imports
        SimplePath Renaming?
 
    CommonPathPrefix ::=
-       SimplePath $$::$$
-     | $$::$$
+       SimplePath? $$::$$
 
    UseImportContentList ::=
        UseImportContent ($$,$$ UseImportContent)* $$,$$?
@@ -1022,28 +1021,40 @@ A :t:`use import` brings :t:`entities <entity>` :t:`in scope` within the
 :t:`use import` resides.
 
 :dp:`fls_sxo1jb25pl8a`
-A :dt:`common path prefix` is the :t:`simple path` of a :s:`CommonPathPrefix` when the :s:`CommonPathPrefix` contains a :s:`SimplePath`, and otherwise consists only of :t:`namespace qualifier` ``::``.
+A :dt:`common path prefix` is the leading :t:`simple path` of a :t:`glob import`
+or a :t:`nesting import`.
 
 :dp:`fls_WAA4WmohGu6T`
-An :dt:`import path prefix` is a sequence of :t:`[path segment]s` and :t:`[namespace qualifier]s` associated with a :t:`simple import` or :t:`glob import`. The :t:`import path prefix` for a given :t:`simple import` or :t:`glob import` is constructed as follows:
-
-#. :dp:`fls_IPYvldMqduf4`
-   Make the given :t:`use import` the current :t:`use import`, and start the :t:`import path prefix` as follows:
-
-   * :dp:`fls_MOXId37fcNPY`
-     If the :t:`use import` is a :t:`simple import`, then start with the :t:`simple import`'s :t:`simple path` after removing its last :t:`path segment` and, if another :t:`path segment` precedes the last :t:`path segment`, the :t:`namespace qualifier` that separates them.
-
-   * :dp:`fls_2UyFcB6Our1v`
-     If the :t:`use import` is a :t:`glob import`, then start with the :t:`glob import`'s :t:`common path prefix`, or an empty sequence if the :t:`glob import` lacks a :t:`common path prefix`.
+An :dt:`import path prefix` is a sequence of :t:`[path segment]s` and
+:t:`[namespace qualifier]s` associated with a :t:`simple import` or
+:t:`glob import`. The :t:`import path prefix` is formed by concatenating the
+following sequences in order. When concatenation would place two
+:t:`[path segment]s` next to each other, :t:`namespace qualifier` ``::`` is
+placed between them.
 
 #. :dp:`fls_gAWsqibl4GLq`
-   While the current :t:`use import` is the child of a :t:`nesting import`, repeat the following steps:
+   For each :t:`nesting import` in which the :t:`simple import` or
+   :t:`glob import` is nested, from outermost to innermost:
 
    * :dp:`fls_irdKqoYzBM0M`
-     If the :t:`nesting import` has a :t:`common path prefix`, prepend the :t:`common path prefix` to the :t:`import path prefix`. If the :t:`common path prefix` contains a :t:`path segment` and the :t:`import path prefix` was not empty, place a :t:`namespace qualifier` ``::`` between them.
+     The :t:`nesting import`'s :t:`common path prefix` if it has one,
+     :t:`namespace qualifier` ``::`` if it lacks a :t:`common path prefix`
+     and its :s:`CommonPathPrefix` is present, or an empty sequence otherwise.
 
-   * :dp:`fls_lfsIPXV0OTI5`
-     Make the :t:`nesting import` the current :t:`use import`.
+#. :dp:`fls_IPYvldMqduf4`
+   A sequence determined by the kind of import:
+
+   * :dp:`fls_MOXId37fcNPY`
+     For a :t:`simple import`, the :t:`simple import`'s :t:`simple path` after
+     removing its last :t:`path segment` and, if another :t:`path segment`
+     precedes the last :t:`path segment`, the :t:`namespace qualifier` that
+     separates them.
+
+   * :dp:`fls_2UyFcB6Our1v`
+     For a :t:`glob import`, the :t:`glob import`'s :t:`common path prefix` if
+     it has one, :t:`namespace qualifier` ``::`` if it lacks a
+     :t:`common path prefix` and its :s:`CommonPathPrefix` is present, or an
+     empty sequence otherwise.
 
 :dp:`fls_2bkcn83smy2y`
 A :dt:`simple import` is a :t:`use import` that brings into :t:`scope` an :t:`entity` selected by its :t:`simple import path`, or by its :t:`import path prefix` when its :t:`simple path` ends in :t:`keyword` ``self``.

--- a/src/entities-and-resolution.rst
+++ b/src/entities-and-resolution.rst
@@ -1019,16 +1019,16 @@ A :t:`use import` brings :t:`entities <entity>` :t:`in scope` within the
 :t:`use import` resides.
 
 :dp:`fls_sxo1jb25pl8a`
-A :dt:`common path prefix` is the :t:`simple path` of a :s:`CommonPathPrefix` when one is present, and otherwise consists only of :t:`namespace qualifier` ``::``.
+A :dt:`common path prefix` is the :t:`simple path` of a :s:`CommonPathPrefix` when the :s:`CommonPathPrefix` contains a :s:`SimplePath`, and otherwise consists only of :t:`namespace qualifier` ``::``.
 
 :dp:`fls_WAA4WmohGu6T`
-An :dt:`import path prefix` is the fully constructed sequence of :t:`[path segment]s` and :t:`[namespace qualifier]s` that precedes the selected :t:`entity` of a :t:`simple import` or the character asterisk ``*`` of a :t:`glob import`. The :t:`import path prefix` for a given :t:`simple import` or :t:`glob import` is constructed as follows:
+An :dt:`import path prefix` is a sequence of :t:`[path segment]s` and :t:`[namespace qualifier]s` associated with a :t:`simple import` or :t:`glob import`. The :t:`import path prefix` for a given :t:`simple import` or :t:`glob import` is constructed as follows:
 
 #. :dp:`fls_IPYvldMqduf4`
    Make the given :t:`use import` the current :t:`use import`, and start the :t:`import path prefix` as follows:
 
    * :dp:`fls_MOXId37fcNPY`
-     If the :t:`use import` is a :t:`simple import`, then start with the :t:`simple import`'s :t:`simple path` :t:`path prefix`, retaining any leading :t:`namespace qualifier` of the :t:`simple path`.
+     If the :t:`use import` is a :t:`simple import`, then start with the :t:`simple import`'s :t:`simple path` after removing its last :t:`path segment` and, if another :t:`path segment` precedes the last :t:`path segment`, the :t:`namespace qualifier` that separates them.
 
    * :dp:`fls_2UyFcB6Our1v`
      If the :t:`use import` is a :t:`glob import`, then start with the :t:`glob import`'s :t:`common path prefix`, or an empty sequence if the :t:`glob import` lacks a :t:`common path prefix`.
@@ -1054,10 +1054,10 @@ into :t:`scope`.
 Each :t:`namespace qualifier` of an :t:`import path prefix` shall either be the first element of the :t:`import path prefix` or appear between two :t:`[path segment]s`.
 
 :dp:`fls_UZHHtqJ0ekju`
-An empty :t:`import path prefix` resolves to the current :t:`module`.
+An empty :t:`import path prefix` that selects the :t:`entity` of a :t:`simple import` resolves to the current :t:`module`.
 
 :dp:`fls_JHU0ersYB6eL`
-An :t:`import path prefix` shall resolve to a :t:`module` or :t:`enum`.
+An :t:`import path prefix` that contains a :t:`path segment` shall resolve to a :t:`module` or :t:`enum`.
 
 :dp:`fls_jlNKxkuhsvX4`
 A :t:`glob import` brings :t:`[name]s` into :t:`scope` as follows:
@@ -1125,7 +1125,7 @@ A :t:`use import` with a single :t:`path segment` expressed as either :t:`keywor
 When a :t:`path segment` expressed as :t:`keyword` ``super`` is used to import a parent :t:`module`, the imported :t:`entity` shall be subject to a :t:`renaming`.
 
 :dp:`fls_aam34hsRmKU2`
-An :t:`import path prefix` shall not consist only of :t:`namespace qualifier` ``::`` when it is the :t:`import path prefix` of a :t:`glob import` or selects the :t:`entity` of a :t:`simple import`.
+The :t:`import path prefix` of a :t:`glob import` shall neither be empty nor consist only of :t:`namespace qualifier` ``::``. An :t:`import path prefix` that selects the :t:`entity` of a :t:`simple import` shall not consist only of :t:`namespace qualifier` ``::``.
 
 :dp:`fls_LV94x3HlpBWk`
 A :t:`simple import` shall not refer to :t:`[enum variant]s` through a :t:`type alias`.

--- a/src/entities-and-resolution.rst
+++ b/src/entities-and-resolution.rst
@@ -1031,16 +1031,16 @@ An :dt:`import path prefix` is a sequence of :t:`[namespace qualifier]s` and :t:
    For each :t:`nesting import` in which the :t:`glob import` or :t:`simple import` is nested, from outermost to innermost:
 
    * :dp:`fls_irdKqoYzBM0M`
-     The :t:`nesting import`'s :t:`common path prefix` if it has one, :t:`namespace qualifier` ``::`` if it lacks a :t:`common path prefix` and its :s:`CommonPathPrefix` is present, or an empty sequence otherwise.
+     The :s:`SimplePath` of the :t:`nesting import`'s :s:`CommonPathPrefix` if that :s:`SimplePath` is present, :t:`namespace qualifier` ``::`` if the :s:`CommonPathPrefix` is present without a :s:`SimplePath`, or an empty sequence if the :s:`CommonPathPrefix` is absent.
 
 #. :dp:`fls_IPYvldMqduf4`
    A sequence determined by the kind of import:
 
    * :dp:`fls_2UyFcB6Our1v`
-     For a :t:`glob import`, the :t:`glob import`'s :t:`common path prefix` if it has one, :t:`namespace qualifier` ``::`` if it lacks a :t:`common path prefix` and its :s:`CommonPathPrefix` is present, or an empty sequence otherwise.
+     For a :t:`glob import`, the :s:`SimplePath` of the :t:`glob import`'s :s:`CommonPathPrefix` if that :s:`SimplePath` is present, :t:`namespace qualifier` ``::`` if the :s:`CommonPathPrefix` is present without a :s:`SimplePath`, or an empty sequence if the :s:`CommonPathPrefix` is absent.
 
    * :dp:`fls_MOXId37fcNPY`
-     For a :t:`simple import`, the :t:`simple import`'s :t:`simple path` after removing its last :t:`path segment` and, if another :t:`path segment` precedes the last :t:`path segment`, the :t:`namespace qualifier` that separates them.
+     For a :t:`simple import`, the :t:`simple import`'s :t:`simple path` after removing the last :t:`path segment` and any :t:`namespace qualifier` ``::`` that separates the last :t:`path segment` from a preceding :t:`path segment`.
 
 :dp:`fls_2bkcn83smy2y`
 A :dt:`simple import` is a :t:`use import` that brings into :t:`scope` an :t:`entity` selected by its :t:`simple import path`, or by its :t:`import path prefix` when its :t:`simple path` ends in :t:`keyword` ``self``.
@@ -1051,10 +1051,10 @@ exported by the :t:`module` or :t:`enum` its :t:`import path prefix` resolves to
 into :t:`scope`.
 
 :dp:`fls_BMtRtjJ7gBKT`
-A :t:`glob import`, :t:`nesting import`, or :t:`simple import` expressed with a leading :t:`namespace qualifier` ``::`` shall not be nested, directly or indirectly, within any :t:`nesting import` whose :s:`CommonPathPrefix` is present.
+A :t:`glob import`, :t:`nesting import`, or :t:`simple import` expressed with a leading :t:`namespace qualifier` ``::`` shall not be nested within any :t:`nesting import` whose :s:`CommonPathPrefix` is present.
 
 :dp:`fls_UZHHtqJ0ekju`
-An empty :t:`import path prefix` that selects the :t:`entity` of a :t:`simple import` resolves to the current :t:`module`.
+An empty :t:`import path prefix` of a :t:`simple import` whose :t:`simple path` is expressed as :t:`keyword` ``self`` resolves to the current :t:`module`.
 
 :dp:`fls_JHU0ersYB6eL`
 An :t:`import path prefix` that contains a :t:`path segment` shall resolve to an :t:`enum` or :t:`module`.
@@ -1103,7 +1103,7 @@ A :t:`nesting import` is a :t:`use import` that provides a common
 :t:`common path prefix` for its nested :t:`[use import]s`.
 
 :dp:`fls_iNUBX5fJAI1N`
-A :t:`glob import` whose :t:`import path prefix` is empty or consists only of :t:`namespace qualifier` ``::`` is rejected, but may still be consumed by :t:`[macro]s`.
+It is a static error if the :t:`import path prefix` of a :t:`glob import` is empty or consists only of :t:`namespace qualifier` ``::``.
 
 :dp:`fls_wB3fVglLOqbZ`
 It is a static error if two :t:`[glob import]s` import the same :t:`name` in the
@@ -1124,7 +1124,7 @@ A :t:`use import` with a single :t:`path segment` expressed as either :t:`keywor
 When a :t:`path segment` expressed as :t:`keyword` ``super`` is used to import a parent :t:`module`, the imported :t:`entity` shall be subject to a :t:`renaming`.
 
 :dp:`fls_aam34hsRmKU2`
-An :t:`import path prefix` that selects the :t:`entity` of a :t:`simple import` shall not consist only of :t:`namespace qualifier` ``::``.
+The :t:`import path prefix` of a :t:`simple import` whose :t:`simple path` is expressed as :t:`keyword` ``self`` shall not consist only of :t:`namespace qualifier` ``::``.
 
 :dp:`fls_LV94x3HlpBWk`
 A :t:`simple import` shall not refer to :t:`[enum variant]s` through a :t:`type alias`.


### PR DESCRIPTION
## Summary

Preserve leading `::` in import path prefixes, distinguishing an empty prefix from bare `::` and qualified paths such as `::std`.

Replace the stateful construction with a declarative definition and reject misplaced root qualifiers, including in empty nested groups.

Clarify the syntax-component, separator, nesting, and self-specific legality wording in response to review.

Reconcile the shadowing rules with explicit global lookup: local names do not prevent `::std` from selecting the external crate. The broader nonglobal ambiguity model and trait-parent rules are unchanged.

Closes rust-lang/fls#711

## Reference alignment

[Rust Reference: use declarations](https://doc.rust-lang.org/reference/items/use-declarations.html)

[Global paths](https://doc.rust-lang.org/reference/paths.html#r-paths.qualifiers.global-root.edition2018) and [prelude shadowing](https://doc.rust-lang.org/reference/names/scopes.html#r-names.scopes.items.shadow-prelude), for Rust 2021.

## Testing

[Documentation CI](https://github.com/rust-lang/fls/actions/runs/34549668338) passes at `dd52e9d`. The clean local build passes; link checker: 17,069 links, zero errors.

All 64 maintained compiler fixtures match expectations using Rust 1.98.0, edition 2021: 38 acceptances and 26 rejections, including the ordinary empty-prefix alias guard. Separate shadowing (8), macro (8), and self-prefix (4) probes also match expectations; these sets overlap and are not a combined unique-case count.
